### PR TITLE
Made retina ink icon forward compatible from Unity version 5.4

### DIFF
--- a/Assets/Plugins/Ink/Editor/Ink Inspector/File Icons/InkBrowserIcons.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Inspector/File Icons/InkBrowserIcons.cs
@@ -15,7 +15,8 @@ namespace Ink.UnityIntegration {
 		private static Texture2D inkFileIcon;
 
 	    static InkBrowserIcons() {
-			if(Application.platform == RuntimePlatform.OSXEditor && Application.unityVersion.Substring(0,3) == ("5.4")) {
+			float unityVersion = float.Parse(Application.unityVersion.Substring (0, 3));
+			if(Application.platform == RuntimePlatform.OSXEditor && unityVersion > 5.4f) {
 				inkFileIcon = Resources.Load<Texture2D>("InkFileIcon-retina");
 	    	} else {
 				inkFileIcon = Resources.Load<Texture2D>("InkFileIcon");


### PR DESCRIPTION
Just scanned this, and it seems really solid. You're much better programmers than I am hah. Just one tiny fix for retina ink icons eventually breaking in future versions of Unity 5.5, 5.6, 6.0 etc