### PR TITLE
Updated InkFile to use unix-style path separators.

### DIFF
--- a/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
@@ -14,58 +14,94 @@ namespace Ink.UnityIntegration {
 	// Helper class for ink files that maintains INCLUDE connections between ink files
 	public class InkFile {
 		
+		// Constant value, used for searching for INCLUDE files in an InkFile.
 		private const string includeKey = "INCLUDE ";
+		
+		// Constant for the number of characters in the word 'Assets', used for 
+		// shortening paths when looking for .ink files in the Assets dir.
+		private const int CharactersInAssets = 6;
 
 		// The full file path
 		public string absoluteFilePath;
+		
+		// The full file path to the .ink file represented by this object.
 		public string absoluteFolderPath;
+		
 		// The file path relative to the Assets folder
 		public string filePath;
 
 		// The content of the .ink file
 		public string fileContents;
+		
 		// The paths of the files included by this file
 		public List<string> includePaths;
+		
 		// The loaded files included by this file
 		public List<InkFile> includes;
+		
 		// If this file is included by another, the other is the master file.
-
 		public InkFile master;
 
 		// A reference to the ink file (UnityEngine.DefaultAsset)
 		public UnityEngine.Object inkFile;
+		
 		// The compiled json file. Use this to start a story.
 		public TextAsset jsonAsset;
 
+		// CONSTRUCTOR.
+		//		Param - string absFilePath - the absolute file path of the InkFile to be represented by this InkFile instance.
 		public InkFile (string absoluteFilePath) {
+			// Set absolute file
 			this.absoluteFilePath = absoluteFilePath;
 			absoluteFolderPath = Path.GetDirectoryName(absoluteFilePath);
-			filePath = absoluteFilePath.Substring(Application.dataPath.Length-6);
+			
+			// Generate the path relative to the Assets directory.
+			filePath = absoluteFilePath.Substring(Application.dataPath.Length - CharactersInAssets);
+			
+			// Read in and set the files contents on 'fileContents'
 			fileContents = File.OpenText(absoluteFilePath).ReadToEnd();
+			
+			// Register a Unity Asset with the Asset Database.
 			inkFile = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(filePath);
+			
+			// find files 'included' by this ink file and its 'master' file.
 			GetIncludePaths();
 		}
-		
+
+		// Determines the paths of .ink files included by this .ink file, as well as the 'Master' file for this InkFIle.
 		private void GetIncludePaths() {
-			if (String.IsNullOrEmpty(includeKey))
-				throw new ArgumentException("the string to find may not be empty", "value");
 			includePaths = new List<string>();
+			
+			// While True...start to search from character 0 for included files.
 			for (int index = 0;;) {
 				index = fileContents.IndexOf(includeKey, index);
 				if (index == -1)
 					return;
 				
+				// If we DID find an include file, we need to process it.
+				// --- Start searching at the index of where we foudn our file and find the end 
+				// --- of the line - this is the index of the character at the end of our include 
+				// --- file.
 				int lastIndex = fileContents.IndexOf("\n", index);
 				if(lastIndex == -1) {
+					// If we didn't find a newline char, then set the current index to after our last INCLUDE, and loop (ie search again).
 					index += includeKey.Length;
 				} else {
-					includePaths.Add(Path.Combine(absoluteFolderPath, fileContents.Substring(index + includeKey.Length, lastIndex - (index+ + includeKey.Length))));
+					// If we did, then that means we have a new include file to add to the includePaths List.
+					// Sanitize file separators before adding to includePaths
+					String toBeIncluded = Path.Combine(absoluteFolderPath, fileContents.Substring(index + IncludeKey.Length, lastIndex - (index+ + IncludeKey.Length)));
+					toBeIncluded = toBeIncluded.Replace ('\\', '/');
+					includePaths.Add(toBeIncluded);
+					
+					// update our index to after the last found INCLUDE and loop  (ie search again).
 					index = lastIndex;
 				}
 			}
 		}
 		
 		// Finds include files from paths and the list of all the ink files to check.
+		// 		param - InkFile[] inkFiles - the inkfiles to search.  This method identifies this InkFile instance's 'Master' 
+		//									 file as well as identifying InkFile that it includes.
 		public void GetIncludes (InkFile[] inkFiles) {
 			includes = new List<InkFile>();
 			foreach (InkFile inkFile in inkFiles) {


### PR DESCRIPTION
This pull request resolves issue #3.  The issue here resulted from an issue with Windows file separators instead of those from Mac/Linux.  This was caused by the call to Path.Combine in the GetIncludePaths() method of InkFile, which would insert a '\' character instead of a '/' character - as would be the norm on non-Windows systems.

The result was that later, when the GetIncludes() method of InkFile was called by InkLibrary, the check to see if the includePaths contained the other inkFile's absoluteFilePath would return False even though the only difference was a forward vs backward slash.

As a small note - sorry about all of the bonus comments etc - I know they sort of pollute the functional change to the source - but they were helpful to me when I was trying to sort out the issue here.  If the comments are not desired, please reject this pull request and I can submit one without them and I'll be a bit more mindful of this in the future.