### PR TITLE
Cleaned up \\ vs / code and Path.Combine calls.

### DIFF
--- a/Assets/Plugins/Ink/Editor/Compiler/Auto Compiler/InkPostProcessor.cs
+++ b/Assets/Plugins/Ink/Editor/Compiler/Auto Compiler/InkPostProcessor.cs
@@ -71,7 +71,10 @@ namespace Ink.UnityIntegration {
 				InkFile inkFile = InkLibrary.GetInkFileWithPath(movedAssets[i]);
 				if(inkFile != null) {
 					string jsonAssetPath = AssetDatabase.GetAssetPath(inkFile.jsonAsset);
-					string newPath = Path.Combine(Path.GetDirectoryName(movedAssets[i]), Path.GetFileNameWithoutExtension(Path.GetFileName(movedAssets[i])))+".json";
+					
+					string movedAssetDir = Path.GetDirectoryName(movedAssets[i]);
+					string movedAssetFile = Path.GetFileName(movedAssets[i]);
+					string newPath = InkEditorUtils.CombinePaths(movedAssetDir, Path.GetFileNameWithoutExtension(movedAssetFile)) + ".json";
 					AssetDatabase.MoveAsset(jsonAssetPath, newPath);
 				}
 			}

--- a/Assets/Plugins/Ink/Editor/Compiler/InkCompiler.cs
+++ b/Assets/Plugins/Ink/Editor/Compiler/InkCompiler.cs
@@ -101,11 +101,9 @@ namespace Ink.UnityIntegration {
 				return;
 			}
 
-			string inputPath = Path.Combine(inkFile.absoluteFolderPath, Path.GetFileName(inkFile.filePath));
-			inputPath = inputPath.Replace ('\\', '/');
-			string outputPath = Path.Combine(inkFile.absoluteFolderPath, Path.GetFileNameWithoutExtension(Path.GetFileName(inkFile.filePath)))+".json";
-			outputPath = outputPath.Replace ('\\', '/');
-			string inkArguments = "-c -o "+"\""+outputPath +"\" \""+inputPath+"\"";
+			string inputPath = InkEditorUtils.CombinePaths(inkFile.absoluteFolderPath, Path.GetFileName(inkFile.filePath));
+			string outputPath = InkEditorUtils.CombinePaths(inkFile.absoluteFolderPath, Path.GetFileNameWithoutExtension(Path.GetFileName(inkFile.filePath))) + ".json";
+			string inkArguments = "-c -o " + "\"" + outputPath + "\" \"" + inputPath + "\"";
 
 			CompilationStackItem pendingFile = new CompilationStackItem();
 			pendingFile.inkFile = InkLibrary.GetInkFileWithAbsolutePath(inputPath);
@@ -220,8 +218,7 @@ namespace Ink.UnityIntegration {
 						message = messageCapture.Value.Trim();
 					
 
-					string logFilePath = Path.Combine(Path.GetDirectoryName(pendingFile.inkFile.filePath), filename);
-					logFilePath = logFilePath.Replace ('\\', '/');
+					string logFilePath = InkEditorUtils.CombinePaths(Path.GetDirectoryName(pendingFile.inkFile.filePath), filename);
 					InkFile inkFile = InkLibrary.GetInkFileWithPath(logFilePath);
 					if(inkFile == null)
 						inkFile = pendingFile.inkFile;

--- a/Assets/Plugins/Ink/Editor/Ink Inspector/Ink Inspector/InkInspector.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Inspector/Ink Inspector/InkInspector.cs
@@ -240,7 +240,7 @@ namespace Ink.UnityIntegration {
 			DateTime lastEditDate = File.GetLastWriteTime(inkFile.absoluteFilePath);
 			editAndCompileDateString += "Last edit date "+lastEditDate.ToString();
 			if(inkFile.isMaster && inkFile.jsonAsset != null) {
-				DateTime lastCompileDate = File.GetLastWriteTime(Path.Combine(Application.dataPath, AssetDatabase.GetAssetPath(masterInkFile.jsonAsset).Substring(7)));
+				DateTime lastCompileDate = File.GetLastWriteTime(InkEditorUtils.CombinePaths(Application.dataPath, AssetDatabase.GetAssetPath(masterInkFile.jsonAsset).Substring(7)));
 				editAndCompileDateString += "\nLast compile date "+lastCompileDate.ToString();
 				if(lastEditDate > lastCompileDate) {
 					editedAfterLastCompile = true;

--- a/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
@@ -28,20 +28,19 @@ namespace Ink.UnityIntegration {
 			get {
 				if(inkAsset == null) 
 					return null;
-				string path = Path.Combine(Application.dataPath, filePath.Substring(7));
-				path = path.Replace ('\\', '/');
-				return path;
+				
+				return InkEditorUtils.CombinePaths(Application.dataPath, filePath.Substring(7));
 			}
 		}
 		public string absoluteFolderPath {
 			get {
-				return Path.GetDirectoryName(absoluteFilePath);
+				return InkEditorUtils.SanitizePathString(Path.GetDirectoryName(absoluteFilePath));
 			}
 		}
 		// The file path relative to the Assets folder
 		public string filePath {
 			get {
-				return AssetDatabase.GetAssetPath(inkAsset);
+				return InkEditorUtils.SanitizePathString(AssetDatabase.GetAssetPath(inkAsset));
 			}
 		}
 
@@ -140,8 +139,7 @@ namespace Ink.UnityIntegration {
 		public void FindIncludedFiles () {
 			includes.Clear();
 			foreach(string includePath in includePaths) {
-				string localIncludePath = Path.Combine(Path.GetDirectoryName(filePath), includePath);
-				localIncludePath = localIncludePath.Replace ('\\', '/');
+				string localIncludePath = InkEditorUtils.CombinePaths(Path.GetDirectoryName(filePath), includePath);
 				DefaultAsset includedInkFileAsset = AssetDatabase.LoadAssetAtPath<DefaultAsset>(localIncludePath);
 				InkFile includedInkFile = InkLibrary.GetInkFileWithFile(includedInkFileAsset);
 				if(includedInkFile == null) {
@@ -154,8 +152,7 @@ namespace Ink.UnityIntegration {
 		}
 
 		public void FindCompiledJSONAsset () {
-			string jsonAssetPath = Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath))+".json";
-			jsonAssetPath = jsonAssetPath.Replace ('\\', '/');
+			string jsonAssetPath = InkEditorUtils.CombinePaths(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath)) + ".json";
 			jsonAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(jsonAssetPath);
 		}
 

--- a/Assets/Plugins/Ink/Editor/Ink Library/InkLibrary.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Library/InkLibrary.cs
@@ -93,7 +93,7 @@ namespace Ink.UnityIntegration {
 		public static string[] GetAllInkFilePaths () {
 			string[] inkFilePaths = Directory.GetFiles(Application.dataPath, "*.ink", SearchOption.AllDirectories);
 			for (int i = 0; i < inkFilePaths.Length; i++) {
-				inkFilePaths [i] = inkFilePaths [i].Replace('\\', '/');
+				inkFilePaths [i] = InkEditorUtils.SanitizePathString(inkFilePaths [i]);
 			}
 			return inkFilePaths;
 		}

--- a/Assets/Plugins/Ink/Editor/Tools/InkEditorUtils.cs
+++ b/Assets/Plugins/Ink/Editor/Tools/InkEditorUtils.cs
@@ -161,5 +161,23 @@ namespace Ink.UnityIntegration {
 				return Path.GetFullPath(inklecateDirectories[0]);
 			}
 		}
+		
+		// Returns a sanitized version of the supplied string by:
+		//    - swapping MS Windows-style file separators with Unix/Mac style file separators.
+		//
+		// If null is provided, null is returned.
+		public static string SanitizePathString(string path) {
+			if (path == null) {
+				return null;
+			}
+			return path.Replace('\\', '/');
+		}
+		
+		// Combines two file paths and returns that path.  Unlike C#'s native Paths.Combine, regardless of operating 
+		// system this method will always return a path which uses forward slashes ('/' characters) exclusively to ensure
+		// equality checks on path strings return equalities as expected.
+		public static string CombinePaths(string firstPath, string secondPath) {
+			return SanitizePathString(Path.Combine(firstPath, secondPath));
+		}
 	}
 }


### PR DESCRIPTION
As Tom and I discussed yesterday, the number of places/times we called .Replace('\\', '/') was getting out of hand, so I said I'd take a look at creating a pull request that aimed to keep InkFile and InkLibrary's internal states entirely /-based so that clients using those classes public API wouldn't have to worry about what kind of slashes they had.

With some of the new changes, that approach was less straightforward than I would have hoped - so instead, I added a couple of public static methods to the InkEditorUtils.cs class.

Problems Solved by this changeset:

1 - We had the line:  someString.replace('\\', '/') EVERYWHERE.  This was error prone, messy and a typo in one of those lines could have led to sometimes having the expected slashes and sometimes not.  This line of code is now centralized in one place and is conveniently used.

2 - We also do a fair bit of Path.Combine() calls.  Following each of these, we always had to do a replace because on windows machines Unity path requests would give us forward slashes and then Windows would add back-slashes, resulting in paths like this:  C:\Some\Paths\Are/Wonky.ink

To solve this issue, I simply wrapped a Path.Combine call in a second toolbox method that does the combine and then in turn sanitizes the string to ensure all slashes are foreward slashes.  This has the effect of cleaning up a lot of messy code and again, keeps things consistent.  I'm not often a fan of replacing language API with something special unless there's a real benefit - and I think here there is one.


Anyways, let me know what you guys think!

- HB