### PR TITLE
BUGFIX: InkFile.FindIncludes() captures a '\r' on the end of any matched include filenames

### DIFF
--- a/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
@@ -142,7 +142,7 @@ namespace Ink.UnityIntegration {
 		public void FindIncludedFiles () {
 			includes.Clear();
 			foreach(string includePath in includePaths) {
-				string localIncludePath = InkEditorUtils.CombinePaths(Path.GetDirectoryName(filePath), includePath);
+				string localIncludePath = InkEditorUtils.CombinePaths(Path.GetDirectoryName(filePath), includePath.Trim('\r'));
 				DefaultAsset includedInkFileAsset = AssetDatabase.LoadAssetAtPath<DefaultAsset>(localIncludePath);
 				InkFile includedInkFile = InkLibrary.GetInkFileWithFile(includedInkFileAsset);
 				if(includedInkFile == null) {

--- a/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
@@ -219,7 +219,7 @@ namespace Ink.UnityIntegration {
 	        void FindIncludes(string str)
 	        {
 	            _includeFilenames = new List<string> ();
-	            var includeRegex = new Regex (@"^\s*INCLUDE\s+(.+)$", RegexOptions.Multiline);
+	            var includeRegex = new Regex (@"^\s*INCLUDE\s+([~\r]+)\r*$", RegexOptions.Multiline);
 	            MatchCollection matches = includeRegex.Matches(str);
 	            foreach (Match match in matches)
 	            {


### PR DESCRIPTION
In Windows when using multiple .ink files and the INCLUDE directive, `InkIncludeParser.FindIncludes()` captures a carriage return ('\r') at the end of the include filename causing  an "Illegal characters in path"
exception to be thrown when `Path.Combine()` is called. My guess is MacOS also suffers from this same issue but I haven't verified it.