### PR TITLE
Fixed 'EditorApplication.playmodeStateChanged' being obselete in Unity version 2017.2 and up

### DIFF
--- a/Assets/Plugins/Ink/Editor/Compiler/InkCompiler.cs
+++ b/Assets/Plugins/Ink/Editor/Compiler/InkCompiler.cs
@@ -46,7 +46,11 @@ namespace Ink.UnityIntegration {
 		}
 
 		static InkCompiler () {
-			EditorApplication.playmodeStateChanged += OnPlayModeChange;
+			#if UNITY_2017_2_OR_NEWER
+				EditorApplication.playModeStateChanged += (state) => OnPlayModeChange();
+			#else
+				EditorApplication.playmodeStateChanged += OnPlayModeChange;
+			#endif
 			EditorApplication.update += Update;
 		}
 


### PR DESCRIPTION
Unity seem to have changed their API a bit regarding `playmodeStateChanged`. I only get a warning message in the Unity Editor console but I thought I'd provide a fix anyways.

The docs unhelpfully don't provide the actual new method signature but I deduced that it had changed based on the new doc example.

Unity 2017.1 and below
https://docs.unity3d.com/2017.1/Documentation/ScriptReference/EditorApplication-playmodeStateChanged.html

Unity 2017.2 and above
https://docs.unity3d.com/ScriptReference/EditorApplication-playModeStateChanged.html

**EDIT:**
I've only tested this in 2017.2 and followed the docs from this page:
https://docs.unity3d.com/Manual/PlatformDependentCompilation.html