### PR TITLE
allow to specify compiled json destination folder

### DIFF
--- a/Assets/Plugins/Ink/Editor/Compiler/InkCompiler.cs
+++ b/Assets/Plugins/Ink/Editor/Compiler/InkCompiler.cs
@@ -143,7 +143,7 @@ namespace Ink.UnityIntegration {
 				Debug.LogWarning("Inklecate path should not contain a space. This might lead to compilation failing. Path is '"+inklecatePath+"'. If you don't see any compilation errors, you can ignore this warning.");
 			}*/
 			string inputPath = InkEditorUtils.CombinePaths(inkFile.absoluteFolderPath, Path.GetFileName(inkFile.filePath));
-			string outputPath = InkEditorUtils.CombinePaths(inkFile.absoluteFolderPath, Path.GetFileNameWithoutExtension(Path.GetFileName(inkFile.filePath))) + ".json";
+			string outputPath = InkEditorUtils.UnityRelativeToAbsolutePath(inkFile.jsonPath);
 			string inkArguments = InkSettings.Instance.customInklecateOptions.additionalCompilerOptions + " -c -o " + "\"" + outputPath + "\" \"" + inputPath + "\"";
 
 			CompilationStackItem pendingFile = new CompilationStackItem();

--- a/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Library/InkFile.cs
@@ -12,6 +12,9 @@ namespace Ink.UnityIntegration {
 		// A reference to the ink file
 		public DefaultAsset inkAsset;
 
+        //specify json destination folder (if None, default to same folder as ink file)
+        public DefaultAsset jsonAssetPath;
+
 		// The compiled json file. Use this to start a story.
 		public TextAsset jsonAsset;
 
@@ -52,14 +55,39 @@ namespace Ink.UnityIntegration {
 			}
 		}
 
+        public string jsonPath {
+			get {
+                DefaultAsset jsonFolder = jsonAssetPath;
+                if (jsonFolder == null) // no path specified for this specific file
+                {
+                    if(InkSettings.Instance.defaultJsonAssetPath != null) 
+                    {
+                        // use default path in InkSettings
+                        jsonFolder = InkSettings.Instance.defaultJsonAssetPath;
+                    }
+
+                    if (jsonFolder == null)
+                    {
+                        //fallback to same folder as .ink file
+                        jsonFolder = AssetDatabase.LoadAssetAtPath<DefaultAsset>(Path.GetDirectoryName(filePath));
+                    }
+                }
+
+                string jsonPath = AssetDatabase.GetAssetPath(jsonFolder);
+                string strJsonAssetPath = InkEditorUtils.CombinePaths(jsonPath, Path.GetFileNameWithoutExtension(filePath)) + ".json";
+
+                return InkEditorUtils.SanitizePathString(strJsonAssetPath);
+			}
+		}
+
 		public InkFile (DefaultAsset inkAsset) {
 			Debug.Assert(inkAsset != null);
 			this.inkAsset = inkAsset;
 		}
 
 		public void FindCompiledJSONAsset () {
-			string jsonAssetPath = InkEditorUtils.CombinePaths(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath)) + ".json";
-			jsonAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(jsonAssetPath);
+            Debug.Assert(inkAsset != null);
+            jsonAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(jsonPath);
 		}
 
 		public override string ToString () {

--- a/Assets/Plugins/Ink/Editor/Ink Settings/InkSettings.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Settings/InkSettings.cs
@@ -32,7 +32,9 @@ namespace Ink.UnityIntegration {
 			}
 		}
 
-		public bool compileAutomatically = true;
+        public DefaultAsset defaultJsonAssetPath;
+
+        public bool compileAutomatically = true;
 		public bool delayInPlayMode = true;
 		public bool handleJSONFilesAutomatically = true;
 

--- a/Assets/Plugins/Ink/Editor/Ink Settings/InkSettingsEditor.cs
+++ b/Assets/Plugins/Ink/Editor/Ink Settings/InkSettingsEditor.cs
@@ -21,7 +21,9 @@ namespace Ink.UnityIntegration {
 			}
 			EditorGUILayout.PropertyField(serializedObject.FindProperty("templateFile"));
 
-			data.compileAutomatically = EditorGUILayout.Toggle(new GUIContent("Compile Ink Automatically", "When disabled, automatic compilation can be enabled on a per-story basis via the inspector for a master story file."), data.compileAutomatically);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("defaultJsonAssetPath"));
+
+            data.compileAutomatically = EditorGUILayout.Toggle(new GUIContent("Compile Ink Automatically", "When disabled, automatic compilation can be enabled on a per-story basis via the inspector for a master story file."), data.compileAutomatically);
 			data.delayInPlayMode = EditorGUILayout.Toggle(new GUIContent("Delay compilation if in Play Mode", "When enabled, ink compilation is delayed if in play mode."), data.delayInPlayMode);
 
 			data.handleJSONFilesAutomatically = EditorGUILayout.Toggle(new GUIContent("Handle JSON Automatically", "Whether JSON files are moved, renamed and deleted along with their ink files."), data.handleJSONFilesAutomatically);


### PR DESCRIPTION
currently : 
when compiling .ink files, the .json is always in the same folder as the .ink
this can be a problem when we want to use 'Resources' folder and avoid having the .ink in those 'Resources' folder, as they are not used in the build.

what's proposed : 
- the InkLibrary has a new field for each inkfile to specify a destination folder for that specific file
if it's empty(default) :
- the InkSettings has now a "Default Json Asset Path" that is used for all .ink that do not have a specific destination set
if it's empty(default)
- fallback to same folder as .ink, just like actual version (so if none of this option is used, nothing changes)