### PR TITLE
Ink runtime adf

### DIFF
--- a/Assets/Plugins/Ink/InkRuntime/Ink-Runtime.asmdef
+++ b/Assets/Plugins/Ink/InkRuntime/Ink-Runtime.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "Ink-Runtime"
+}

--- a/Assets/Plugins/Ink/InkRuntime/Ink-Runtime.asmdef.meta
+++ b/Assets/Plugins/Ink/InkRuntime/Ink-Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 58bed0e7c5306824586d7eda03609289
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Unity 2017.3 introduced a new feature: [Assembly Definition Files](https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html).

It helps reduce the compilation time, and allows users to fine-tune their building dependency chain.

I started using them, and the downside I found is that you can't use code if it's not part of the Unity core or a manually referenced Assembly Definition File. What that means is I couldn't use Ink inside of my assembly.
So I had to create an assembly for it.

Thought it might be worth sharing with a PR.

Feel free to edit the name of the assembly, if `Ink-Runtime` doesn't suit you