### PR TITLE
Ignoring BOMChar if users input an UTF8 BOM string

### DIFF
--- a/Assets/Plugins/Ink/InkLibs/InkRuntime/SimpleJson.cs
+++ b/Assets/Plugins/Ink/InkLibs/InkRuntime/SimpleJson.cs
@@ -283,12 +283,14 @@ namespace Ink.Runtime
                     throw new System.Exception (message);
                 }
             }
-
+			
+			private const char BOMChar = (char)65279;
+			
             void SkipWhitespace ()
             {
                 while (_offset < _text.Length) {
                     var c = _text [_offset];
-                    if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+                    if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == BOMChar)
                         _offset++;
                     else
                         break;

--- a/Assets/Plugins/Ink/InkLibs/InkRuntime/SimpleJson.cs
+++ b/Assets/Plugins/Ink/InkLibs/InkRuntime/SimpleJson.cs
@@ -23,11 +23,16 @@ namespace Ink.Runtime
 
         class Reader
         {
+			
+			private const char BOMChar = (char)65279;
+			
             public Reader (string text)
             {
                 _text = text;
                 _offset = 0;
-
+				if (_text[_offset] == UTF8_BOM_char) {
+                    _offset++;
+                }
                 SkipWhitespace ();
 
                 _rootObject = ReadObject ();
@@ -284,13 +289,13 @@ namespace Ink.Runtime
                 }
             }
 			
-			private const char BOMChar = (char)65279;
+			
 			
             void SkipWhitespace ()
             {
                 while (_offset < _text.Length) {
                     var c = _text [_offset];
-                    if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == BOMChar)
+                    if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
                         _offset++;
                     else
                         break;


### PR DESCRIPTION
The first character of UTF8 BOM string is the character with decimal "65279". If you input this string to the ink parser it will crash and just adding this comparission solves the issue.
I read a comment on the web that suggests that the parser should handle this. Maybe a better solutions is to check only on the start of the string, but this is working.