### PR TITLE
fixed: ink compiler gets sometimes stuck when starting game

### DIFF
--- a/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
+++ b/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
@@ -114,6 +114,9 @@ namespace Ink.UnityIntegration {
 					}
                 }
             }
+	    
+	    if(compiling && InkLibrary.NumFilesInCompilingStackInState(CompilationStackItem.State.Compiling) == 0)
+	        TryCompileNextFileInStack();
 
 
 			// If we're not showing a progress bar in Linux this whole step is superfluous


### PR DESCRIPTION
We occasionally (but frequent enough to be a real productivity issue) see the ink compiler getting stuck when starting the game in the editor. The window would say "Compiling Ink file 57 of 57" but just never finish. Our investigation concluded that the ink complier is in the compiling state but no files are in the state Compiling. This fix addresses the issue but doesn't fix the underlying cause of how this can happen in the first place.