### PR TITLE
Feature/rebuild to ink library window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Bin/
 # Other files #
 # =========== #
 *~
+.idea/

--- a/Assets/Editor/InkLibraryEditor.cs
+++ b/Assets/Editor/InkLibraryEditor.cs
@@ -54,6 +54,11 @@ namespace Ink.UnityIntegration {
 		public override void OnInspectorGUI() {
 			serializedObject.Update();
 
+			EditorGUI.BeginDisabledGroup(InkCompiler.compiling);
+			if (GUILayout.Button(new GUIContent("Rebuild Library", "Rebuilds the ink library. Do this if you're getting unusual errors"), EditorStyles.miniButton)) {
+				InkLibrary.Rebuild();
+			}
+			EditorGUI.EndDisabledGroup();
 
 			EditorGUILayout.Toggle("HasLockedUnityCompilation", InkCompiler.hasLockedUnityCompilation);
 			if(GUILayout.Button("Unlock")) {


### PR DESCRIPTION
Now that `InkLibrary.asset` is no longer in the `Assets` directory, I wasn't able to find the `Rebuild Ink Library` button in the Inspector which I often use to test with. I expected it to be in the Ink Library Editor window, but it wasn't there. I now see that there is an option in under `Assets > Rebuild Ink Library`, but I thought this might be helpful for others looking for it and quick access.

This pull request adds the rebuild button to the Library complete with it's tooltip:
![image](https://user-images.githubusercontent.com/73082145/108185740-81ed7c80-7171-11eb-8b94-19d0f5698cda.png)

I've also added the `.idea` folder to the `.gitignore` file as I use Rider and the files in that folder kept appearing in the changelist.