### PR TITLE
Disabled specific warnings

### DIFF
--- a/Assets/Ink/Demos/Basic Demo/Scripts/BasicInkExample.cs
+++ b/Assets/Ink/Demos/Basic Demo/Scripts/BasicInkExample.cs
@@ -16,7 +16,9 @@ public class BasicInkExample : MonoBehaviour {
 	// Creates a new Story object with the compiled story which we can then play!
 	void StartStory () {
 		story = new Story (inkJSONAsset.text);
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
         if(OnCreateStory != null) OnCreateStory(story);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 		RefreshView();
 	}
 	

--- a/Assets/Ink/Demos/Basic Demo/Scripts/BasicInkExample.cs
+++ b/Assets/Ink/Demos/Basic Demo/Scripts/BasicInkExample.cs
@@ -98,15 +98,23 @@ public class BasicInkExample : MonoBehaviour {
 	}
 
 	[SerializeField]
+#pragma warning disable IDE0044 // Add readonly modifier
 	private TextAsset inkJSONAsset = null;
+#pragma warning restore IDE0044 // Add readonly modifier
 	public Story story;
 
 	[SerializeField]
+#pragma warning disable IDE0044 // Add readonly modifier
 	private Canvas canvas = null;
+#pragma warning restore IDE0044 // Add readonly modifier
 
 	// UI Prefabs
 	[SerializeField]
+#pragma warning disable IDE0044 // Add readonly modifier
 	private Text textPrefab = null;
+#pragma warning restore IDE0044 // Add readonly modifier
 	[SerializeField]
+#pragma warning disable IDE0044 // Add readonly modifier
 	private Button buttonPrefab = null;
+#pragma warning restore IDE0044 // Add readonly modifier
 }

--- a/Assets/Ink/Demos/Basic Demo/Scripts/BasicInkExample.cs
+++ b/Assets/Ink/Demos/Basic Demo/Scripts/BasicInkExample.cs
@@ -7,7 +7,9 @@ using Ink.Runtime;
 public class BasicInkExample : MonoBehaviour {
     public static event Action<Story> OnCreateStory;
 	
+#pragma warning disable IDE0051 // Remove unused private members
     void Awake () {
+#pragma warning restore IDE0051 // Remove unused private members
 		// Remove the default message
 		RemoveChildren();
 		StartStory();

--- a/Assets/Ink/Demos/Basic Demo/Scripts/QuitGameOnKeypress.cs
+++ b/Assets/Ink/Demos/Basic Demo/Scripts/QuitGameOnKeypress.cs
@@ -5,7 +5,9 @@ public class QuitGameOnKeypress : MonoBehaviour {
 	
 	public KeyCode key = KeyCode.Escape;
 	
+#pragma warning disable IDE0051 // Remove unused private members
 	void Update () {
+#pragma warning restore IDE0051 // Remove unused private members
 		if(Input.GetKeyDown(key)) Application.Quit();
 	}
 }

--- a/Assets/Publishing/Editor/Tools/PublishingTools.cs
+++ b/Assets/Publishing/Editor/Tools/PublishingTools.cs
@@ -103,7 +103,9 @@ public static class PublishingTools {
 		// AssetDatabase.DisallowAutoRefresh();
 		// #endif
 		var assetsInkPath = Path.Combine(Application.dataPath, "Ink");
+#pragma warning disable IDE0090 // Use 'new(...)'
 		List<KeyValuePair<DirectoryInfo, DirectoryInfo>> rootPaths = new List<KeyValuePair<DirectoryInfo, DirectoryInfo>>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		// Copy the plugin into assets, make a package
 		var integrationDirs = Directory.GetDirectories(IntegrationPath);
 		foreach(var dir in integrationDirs) {

--- a/Packages/Ink/Editor/Core/Compiler/Auto Compiler/InkPostProcessor.cs
+++ b/Packages/Ink/Editor/Core/Compiler/Auto Compiler/InkPostProcessor.cs
@@ -18,7 +18,9 @@ namespace Ink.UnityIntegration {
 #pragma warning restore IDE0044 // Add readonly modifier
 		public static bool disabled = false;
 		// Recompiles any ink files as a result of an ink file (re)import
+#pragma warning disable IDE0051 // Remove unused private members
 		private static void OnPostprocessAllAssets (string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths) {
+#pragma warning restore IDE0051 // Remove unused private members
 			if(disabled) return;
 			if(deletedAssets.Length > 0) {
 				OnDeleteAssets(deletedAssets);

--- a/Packages/Ink/Editor/Core/Compiler/Auto Compiler/InkPostProcessor.cs
+++ b/Packages/Ink/Editor/Core/Compiler/Auto Compiler/InkPostProcessor.cs
@@ -120,7 +120,9 @@ namespace Ink.UnityIntegration {
 				foreach(var inkFilePath in queuedMovedAssets) {
 					InkFile inkFile = InkLibrary.GetInkFileWithPath(inkFilePath);
 					if(inkFile == null) continue;
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
 					foreach(var masterInkFile in inkFile.masterInkFilesIncludingSelf) {
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 						if(!filesToCompile.Contains(inkFile))
 							filesToCompile.Add(inkFile);
 					}
@@ -133,7 +135,9 @@ namespace Ink.UnityIntegration {
 					InkFile inkFile = InkLibrary.GetInkFileWithPath(inkFilePath);
 					if(inkFile == null) continue;
 
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
 					foreach(var masterInkFile in inkFile.masterInkFilesIncludingSelf) {
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 						if(!filesToCompile.Contains(inkFile))
 							filesToCompile.Add(inkFile);
 					}

--- a/Packages/Ink/Editor/Core/Compiler/Auto Compiler/InkPostProcessor.cs
+++ b/Packages/Ink/Editor/Core/Compiler/Auto Compiler/InkPostProcessor.cs
@@ -12,7 +12,9 @@ namespace Ink.UnityIntegration {
 		// This queue tells the compiler which files to recompile after moves have completed.
 		// Not a perfect solution - If Unity doesn't move all the files in the same attempt you can expect some error messages to appear on compile.
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		private static List<string> queuedMovedAssets = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 		public static bool disabled = false;
 		// Recompiles any ink files as a result of an ink file (re)import
@@ -46,7 +48,9 @@ namespace Ink.UnityIntegration {
 
 //			bool alsoDeleteJSON = false;
 //			alsoDeleteJSON = EditorUtility.DisplayDialog("Deleting .ink file", "Also delete the JSON file associated with the deleted .ink file?", "Yes", "No"));
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<InkFile> masterFilesAffected = new List<InkFile>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			for (int i = InkLibrary.instance.inkLibrary.Count - 1; i >= 0; i--) {
 				if(InkLibrary.instance.inkLibrary [i].inkAsset == null) {
 					if(!InkLibrary.instance.inkLibrary[i].isMaster) {
@@ -79,7 +83,9 @@ namespace Ink.UnityIntegration {
 			if (!InkSettings.instance.handleJSONFilesAutomatically) 
 				return;
 			
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<string> validMovedAssets = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			for (var i = 0; i < movedAssets.Length; i++) {
 				if(!InkEditorUtils.IsInkFile(movedAssets[i]))
 					continue;
@@ -106,7 +112,9 @@ namespace Ink.UnityIntegration {
 
 			// Check if no JSON assets were moved (as a result of none needing to move, or this function being called as a result of JSON files being moved)
 			if(!assetMoved && queuedMovedAssets.Count > 0) {
+#pragma warning disable IDE0090 // Use 'new(...)'
 				List<InkFile> filesToCompile = new List<InkFile>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
 				// Add the old master file to the files to be recompiled
 				foreach(var inkFilePath in queuedMovedAssets) {
@@ -145,7 +153,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		private static void OnImportAssets (string[] importedAssets) {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<string> importedInkAssets = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			string inklecateFileLocation = null;
 			foreach (var importedAssetPath in importedAssets) {
 				if(InkEditorUtils.IsInkFile(importedAssetPath))

--- a/Packages/Ink/Editor/Core/Compiler/Auto Compiler/InkPostProcessor.cs
+++ b/Packages/Ink/Editor/Core/Compiler/Auto Compiler/InkPostProcessor.cs
@@ -11,7 +11,9 @@ namespace Ink.UnityIntegration {
 		// Several assets moved at the same time can cause unity to call OnPostprocessAllAssets several times as a result of moving additional files, or simply due to minor time differences.
 		// This queue tells the compiler which files to recompile after moves have completed.
 		// Not a perfect solution - If Unity doesn't move all the files in the same attempt you can expect some error messages to appear on compile.
+#pragma warning disable IDE0044 // Add readonly modifier
 		private static List<string> queuedMovedAssets = new List<string>();
+#pragma warning restore IDE0044 // Add readonly modifier
 		public static bool disabled = false;
 		// Recompiles any ink files as a result of an ink file (re)import
 		private static void OnPostprocessAllAssets (string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths) {

--- a/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
+++ b/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
@@ -424,7 +424,9 @@ namespace Ink.UnityIntegration {
 				countAllVisits = true,
 				fileHandler = new UnityInkFileHandler(Path.GetDirectoryName(item.inkAbsoluteFilePath)),
 				errorHandler = (string message, ErrorType type) => {
+#pragma warning disable IDE0018 // Inline variable declaration
 					InkCompilerLog log;
+#pragma warning restore IDE0018 // Inline variable declaration
 					if(InkCompilerLog.TryParse(message, out log)) {
 						if(string.IsNullOrEmpty(log.fileName)) log.fileName = Path.GetFileName(item.inkAbsoluteFilePath);
 						item.logOutput.Add(log);

--- a/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
+++ b/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
@@ -69,7 +69,9 @@ namespace Ink.UnityIntegration {
 		
         
         public class AssetSaver : UnityEditor.AssetModificationProcessor {
+#pragma warning disable IDE0051 // Remove unused private members
             static string[] OnWillSaveAssets(string[] paths) {
+#pragma warning restore IDE0051 // Remove unused private members
                 InkCompiler.instance.Save(true);
                 return paths;
             }
@@ -153,7 +155,9 @@ namespace Ink.UnityIntegration {
 
 		// This always runs after the InkEditorUtils constructor
 		[InitializeOnLoadMethod]
+#pragma warning disable IDE0051 // Remove unused private members
 		static void OnProjectLoadedInEditor() {
+#pragma warning restore IDE0051 // Remove unused private members
 			#if UNITY_2017_1_OR_NEWER
 			EditorApplication.playModeStateChanged += OnPlayModeChange;
 			#else

--- a/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
+++ b/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
@@ -96,15 +96,21 @@ namespace Ink.UnityIntegration {
 		public static bool hasLockedUnityCompilation = false;
         
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         private static List<Action> onCompleteActions = new List<Action>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 
 		
 		// If InkSettings' delayInPlayMode option is true, dirty files are added here when they're changed in play mode
 		// This ensures they're remembered when you exit play mode and can be compiled
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<string> pendingCompilationStack = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		// The state of files currently being compiled.
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<InkCompiler.CompilationStackItem> compilationStack = new List<InkCompiler.CompilationStackItem>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
 
 		[Serializable]
@@ -126,8 +132,12 @@ namespace Ink.UnityIntegration {
 			public string compiledJson;
 			public string inkAbsoluteFilePath;
 			public string jsonAbsoluteFilePath;
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public List<InkCompilerLog> logOutput = new List<InkCompilerLog>();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public List<string> unhandledErrorOutput = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			public DateTime startTime;
 			public DateTime endTime;
 
@@ -301,10 +311,14 @@ namespace Ink.UnityIntegration {
             
 			InkLibrary.Validate();
             if(onComplete != null) onCompleteActions.Add(onComplete);
+#pragma warning disable IDE0090 // Use 'new(...)'
 			StringBuilder filesCompiledLog = new StringBuilder("Files compiled:");
+#pragma warning restore IDE0090 // Use 'new(...)'
 			foreach (var inkFile in inkFiles) filesCompiledLog.AppendLine().Append(inkFile.filePath);
 			
+#pragma warning disable IDE0090 // Use 'new(...)'
 			StringBuilder outputLog = new StringBuilder ();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			outputLog.Append ("Ink compilation started at ");
 			outputLog.AppendLine (DateTime.Now.ToLongTimeString ());
 			outputLog.Append (filesCompiledLog.ToString());
@@ -343,7 +357,9 @@ namespace Ink.UnityIntegration {
 			string inputPath = InkEditorUtils.CombinePaths(inkFile.absoluteFolderPath, Path.GetFileName(inkFile.filePath));
 			Debug.Assert(inkFile.absoluteFilePath == inputPath);
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			CompilationStackItem pendingFile = new CompilationStackItem
+#pragma warning restore IDE0090 // Use 'new(...)'
 			{
 				inkFile = InkLibrary.GetInkFileWithAbsolutePath(inputPath),
 				inkAbsoluteFilePath = inputPath,
@@ -447,11 +463,15 @@ namespace Ink.UnityIntegration {
 			}
             // Clone and clear the list. This is a surefire way to ensure the list is cleared in case of unhandled errors in this code.
             // A Try-catch would be better but I'm debugging blind as I write this and the nuclear option will definitely work!
+#pragma warning disable IDE0090 // Use 'new(...)'
             List<CompilationStackItem> compilationStack = new List<CompilationStackItem>(instance.compilationStack);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			ClearCompilationStack();
 
 			bool errorsFound = false;
+#pragma warning disable IDE0090 // Use 'new(...)'
 			StringBuilder filesCompiledLog = new StringBuilder("Files compiled:");
+#pragma warning restore IDE0090 // Use 'new(...)'
 
             // Create and import compiled files
 			AssetDatabase.StartAssetEditing();
@@ -474,7 +494,9 @@ namespace Ink.UnityIntegration {
                     filesCompiledLog.Append(string.Format(" ({0}s)", compilingFile.timeTaken));
                     if(compilingFile.unhandledErrorOutput.Count > 0) {
                         filesCompiledLog.Append(" (With unhandled error)");
+#pragma warning disable IDE0090 // Use 'new(...)'
                         StringBuilder errorLog = new StringBuilder ();
+#pragma warning restore IDE0090 // Use 'new(...)'
                         errorLog.Append ("Unhandled error(s) occurred compiling Ink file ");
                         errorLog.Append ("'");
                         errorLog.Append (compilingFile.inkFile.filePath);
@@ -521,7 +543,9 @@ namespace Ink.UnityIntegration {
 				}
 			}
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			StringBuilder outputLog = new StringBuilder ();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			if(errorsFound) {
 				outputLog.Append ("Ink compilation completed with errors at ");
 				outputLog.AppendLine (DateTime.Now.ToLongTimeString ());
@@ -609,7 +633,9 @@ namespace Ink.UnityIntegration {
 
 
 		public static List<InkFile> GetUniqueMasterInkFilesToCompile (List<string> importedInkAssets) {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<InkFile> masterInkFiles = new List<InkFile>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			foreach (var importedAssetPath in importedInkAssets) {
                 foreach(var masterInkFile in GetMasterFilesIncludingInkAssetPath(importedAssetPath)) {
 					if (!masterInkFiles.Contains(masterInkFile) && (InkSettings.instance.compileAutomatically || masterInkFile.compileAutomatically)) {
@@ -683,7 +709,9 @@ namespace Ink.UnityIntegration {
 			return count;
 		}
 		public static List<InkCompiler.CompilationStackItem> FilesInCompilingStackInState (InkCompiler.CompilationStackItem.State state) {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<InkCompiler.CompilationStackItem> items = new List<InkCompiler.CompilationStackItem>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			foreach(var x in instance.compilationStack) {
 				if(x.state == state) 
 					items.Add(x);

--- a/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
+++ b/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿#pragma warning disable IDE1006
+
+using UnityEngine;
 using UnityEditor;
 using System;
 using System.Collections.Generic;

--- a/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
+++ b/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
@@ -513,7 +513,9 @@ namespace Ink.UnityIntegration {
 
 			foreach (var compilingFile in compilationStack) {
 				if (OnCompileInk != null) {
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
 					OnCompileInk (compilingFile.inkFile);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 				}
 			}
 
@@ -567,7 +569,9 @@ namespace Ink.UnityIntegration {
 			}
 
             foreach(var onCompleteAction in onCompleteActions) {
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
                 if(onCompleteAction != null) onCompleteAction();
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
             }
             onCompleteActions.Clear();
 		}

--- a/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
+++ b/Packages/Ink/Editor/Core/Compiler/InkCompiler.cs
@@ -95,7 +95,9 @@ namespace Ink.UnityIntegration {
 		// Track if we've currently locked compilation of Unity C# Scripts
 		public static bool hasLockedUnityCompilation = false;
         
+#pragma warning disable IDE0044 // Add readonly modifier
         private static List<Action> onCompleteActions = new List<Action>();
+#pragma warning restore IDE0044 // Add readonly modifier
 
 		
 		// If InkSettings' delayInPlayMode option is true, dirty files are added here when they're changed in play mode

--- a/Packages/Ink/Editor/Core/Ink Library/InkCompilerLog.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkCompilerLog.cs
@@ -53,6 +53,8 @@ namespace Ink.UnityIntegration
 				return false;
 			}
 		}
+#pragma warning disable IDE0044 // Add readonly modifier
 		private static Regex _errorRegex = new Regex(@"(?<errorType>ERROR|WARNING|TODO):(?:\s(?:'(?<filename>[^']*)'\s)?line (?<lineNo>\d+):)?(?<message>.*)");
+#pragma warning restore IDE0044 // Add readonly modifier
 	}
 }

--- a/Packages/Ink/Editor/Core/Ink Library/InkCompilerLog.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkCompilerLog.cs
@@ -54,7 +54,9 @@ namespace Ink.UnityIntegration
 			}
 		}
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		private static Regex _errorRegex = new Regex(@"(?<errorType>ERROR|WARNING|TODO):(?:\s(?:'(?<filename>[^']*)'\s)?line (?<lineNo>\d+):)?(?<message>.*)");
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 	}
 }

--- a/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
@@ -93,7 +93,9 @@ namespace Ink.UnityIntegration {
 
 
 		// Fatal unhandled errors that should be reported as compiler bugs.
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<string> unhandledCompileErrors = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		public bool hasUnhandledCompileErrors {
 			get {
 				return unhandledCompileErrors.Count > 0;
@@ -101,21 +103,27 @@ namespace Ink.UnityIntegration {
 		}
 
 		// Fatal errors caused by errors in the user's ink script.
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<InkCompilerLog> errors = new List<InkCompilerLog>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		public bool hasErrors {
 			get {
 				return errors.Count > 0;
 			}
 		}
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<InkCompilerLog> warnings = new List<InkCompilerLog>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		public bool hasWarnings {
 			get {
 				return warnings.Count > 0;
 			}
 		}
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<InkCompilerLog> todos = new List<InkCompilerLog>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		public bool hasTodos {
 			get {
 				return todos.Count > 0;
@@ -204,12 +212,18 @@ namespace Ink.UnityIntegration {
 
 		// The files included by this file
 		// We cache the paths of the files to be included for performance, giving us more freedom to refresh the actual includes list without needing to parse all the text.
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<string> includePaths = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<DefaultAsset> includes = new List<DefaultAsset>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		// The InkFiles of the includes of this file
 		public List<InkFile> includesInkFiles {
 			get {
+#pragma warning disable IDE0090 // Use 'new(...)'
 				List<InkFile> _includesInkFiles = new List<InkFile>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 				foreach(var child in includes) {
 					if(child == null) {
 						Debug.LogError("Error compiling ink: Ink file include in "+filePath+" is null.", inkAsset);
@@ -223,7 +237,9 @@ namespace Ink.UnityIntegration {
 		// The InkFiles in the include hierarchy of this file.
 		public List<InkFile> inkFilesInIncludeHierarchy {
 			get {
+#pragma warning disable IDE0090 // Use 'new(...)'
 				List<InkFile> _inkFilesInIncludeHierarchy = new List<InkFile>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 				_inkFilesInIncludeHierarchy.Add(this);
 				foreach(var child in includesInkFiles) {
 					if (child == null)

--- a/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
@@ -240,7 +240,9 @@ namespace Ink.UnityIntegration {
 		public List<InkFile> inkFilesInIncludeHierarchy {
 			get {
 #pragma warning disable IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0028 // Simplify collection initialization
 				List<InkFile> _inkFilesInIncludeHierarchy = new List<InkFile>();
+#pragma warning restore IDE0028 // Simplify collection initialization
 #pragma warning restore IDE0090 // Use 'new(...)'
 				_inkFilesInIncludeHierarchy.Add(this);
 				foreach(var child in includesInkFiles) {

--- a/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE1006
+
 using UnityEngine;
 using UnityEditor;
 using System.IO;

--- a/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
@@ -147,7 +147,9 @@ namespace Ink.UnityIntegration {
 					string fullJSONFilePath = InkEditorUtils.UnityRelativeToAbsolutePath(AssetDatabase.GetAssetPath(jsonAsset));
 					return File.GetLastWriteTime(fullJSONFilePath);
 				} else {
+#pragma warning disable IDE0034 // Simplify 'default' expression
 					return default(DateTime);
+#pragma warning restore IDE0034 // Simplify 'default' expression
 				}
 			}
 		}

--- a/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkFile.cs
@@ -349,7 +349,9 @@ namespace Ink.UnityIntegration {
 	                        if (endOfCommentIdx == -1)
 	                            endOfCommentIdx = inkStr.Length;
 	                        else if (inkStr [endOfCommentIdx - 1] == '\r')
+#pragma warning disable IDE0054 // Use '--' operator
 	                            endOfCommentIdx = endOfCommentIdx - 1;
+#pragma warning restore IDE0054 // Use '--' operator
 	                    } 
 	                    // Block comments
 	                    else if (commentStarter == "/*") {

--- a/Packages/Ink/Editor/Core/Ink Library/InkLibrary.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkLibrary.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE1006
+
 using UnityEngine;
 using UnityEditor;
 using UnityEditorInternal;

--- a/Packages/Ink/Editor/Core/Ink Library/InkLibrary.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkLibrary.cs
@@ -89,7 +89,9 @@ namespace Ink.UnityIntegration {
         #endif
         
         public class AssetSaver : UnityEditor.AssetModificationProcessor {
+#pragma warning disable IDE0051 // Remove unused private members
             static string[] OnWillSaveAssets(string[] paths) {
+#pragma warning restore IDE0051 // Remove unused private members
                 instance.Save(true);
                 return paths;
             }
@@ -120,12 +122,16 @@ namespace Ink.UnityIntegration {
             return inkLibrary.GetEnumerator();
         }
 
+#pragma warning disable IDE0051 // Remove unused private members
 		void OnValidate () {
+#pragma warning restore IDE0051 // Remove unused private members
             BuildLookupDictionary();
             Validate();
         }
 		// After recompile, the data associated with the object is fetched (or whatever happens to it) by this point. 
+#pragma warning disable IDE0051 // Remove unused private members
 		void OnEnable () {
+#pragma warning restore IDE0051 // Remove unused private members
 			// Deletes the persistent version of this asset that we used to use prior to 0.9.71
 			if(!Application.isPlaying && EditorUtility.IsPersistent(this)) {
 				var path = AssetDatabase.GetAssetPath(this);

--- a/Packages/Ink/Editor/Core/Ink Library/InkLibrary.cs
+++ b/Packages/Ink/Editor/Core/Ink Library/InkLibrary.cs
@@ -22,8 +22,12 @@ namespace Ink.UnityIntegration {
 	public class InkLibrary : ScriptableObject, IEnumerable<InkFile> {
     #endif
         // Ink version. This should really come from the core ink code.
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public static System.Version inkVersionCurrent = new System.Version(1,0,0);
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public static System.Version unityIntegrationVersionCurrent = new System.Version(1,0,2);
+#pragma warning restore IDE0090 // Use 'new(...)'
 
 		static string absoluteSavePath {
 			get {
@@ -91,7 +95,9 @@ namespace Ink.UnityIntegration {
             }
         }
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<InkFile> inkLibrary = new List<InkFile>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		Dictionary<DefaultAsset, InkFile> inkLibraryDictionary;
 		
         public int Count {
@@ -234,7 +240,9 @@ namespace Ink.UnityIntegration {
 			// Add any new file connections (if any are found it replaces the old library entirely)
 			string[] inkFilePaths = GetAllInkFilePaths();
 			bool inkLibraryChanged = false;
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<InkFile> newInkLibrary = new List<InkFile>(inkFilePaths.Length);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			for (int i = 0; i < inkFilePaths.Length; i++) {
 				InkFile inkFile = GetInkFileWithAbsolutePath(inkFilePaths [i]);
 				// If the ink library doesn't have a representation for this file, then make one 
@@ -345,13 +353,17 @@ namespace Ink.UnityIntegration {
 			}
 
 			if (addIfMissing) {
+#pragma warning disable IDE0090 // Use 'new(...)'
 				InkFile newFile = new InkFile(file);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				instance.inkLibrary.Add(newFile);
 				Debug.Log(file + " missing from ink library. Adding it now.");
 				return newFile;
 			}
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			System.Text.StringBuilder listOfFiles = new System.Text.StringBuilder();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			foreach(InkFile inkFile in instance.inkLibrary) {
 				listOfFiles.AppendLine(inkFile.ToString());
 			}
@@ -394,7 +406,9 @@ namespace Ink.UnityIntegration {
 		/// Rebuilds which files are master files and the connections between the files.
 		/// </summary>
 		public static void RebuildInkFileConnections () {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			Queue<InkFile> inkFileQueue = new Queue<InkFile>(instance.inkLibrary);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			while (inkFileQueue.Count > 0) {
 				InkFile inkFile = inkFileQueue.Dequeue();
 				inkFile.parents = new List<DefaultAsset>();
@@ -425,7 +439,9 @@ namespace Ink.UnityIntegration {
 				}
 			}
 			// Next, we create a list of all the files owned by the actual master file, which we obtain by travelling up the parent tree from each file.
+#pragma warning disable IDE0090 // Use 'new(...)'
 			Dictionary<InkFile, List<InkFile>> masterChildRelationships = new Dictionary<InkFile, List<InkFile>>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			foreach (InkFile inkFile in instance.inkLibrary) {
 				foreach(var parentInkFile in inkFile.parentInkFiles) {
 					InkFile lastMasterInkFile = parentInkFile;

--- a/Packages/Ink/Editor/Core/Ink Settings/InkSettings.cs
+++ b/Packages/Ink/Editor/Core/Ink Settings/InkSettings.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE1006
+
 using UnityEngine;
 using UnityEditor;
 using Debug = UnityEngine.Debug;

--- a/Packages/Ink/Editor/Core/Ink Settings/InkSettings.cs
+++ b/Packages/Ink/Editor/Core/Ink Settings/InkSettings.cs
@@ -60,7 +60,9 @@ namespace Ink.UnityIntegration {
         #endif
 
         public class AssetSaver : UnityEditor.AssetModificationProcessor {
+#pragma warning disable IDE0051 // Remove unused private members
             static string[] OnWillSaveAssets(string[] paths) {
+#pragma warning restore IDE0051 // Remove unused private members
                 InkSettings.instance.Save(true);
                 return paths;
             }
@@ -99,7 +101,9 @@ namespace Ink.UnityIntegration {
 		#endif
         
 		// Deletes the persistent version of this asset that we used to use prior to 0.9.71
+#pragma warning disable IDE0051 // Remove unused private members
 		void OnEnable () {
+#pragma warning restore IDE0051 // Remove unused private members
 			if(!Application.isPlaying && EditorUtility.IsPersistent(this)) {
 				var path = AssetDatabase.GetAssetPath(this);
 				if(!string.IsNullOrEmpty(path)) {

--- a/Packages/Ink/Editor/Core/InkEditorUtils.cs
+++ b/Packages/Ink/Editor/Core/InkEditorUtils.cs
@@ -17,7 +17,9 @@ namespace Ink.UnityIntegration {
 		public override void Action(int instanceId, string pathName, string resourceFile) {
 			var text = "";
 			if(File.Exists(resourceFile)) {
+#pragma warning disable IDE0090 // Use 'new(...)'
 				StreamReader streamReader = new StreamReader(resourceFile);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				text = streamReader.ReadToEnd();
 				streamReader.Close();
 			}
@@ -27,9 +29,13 @@ namespace Ink.UnityIntegration {
 		
 		internal static UnityEngine.Object CreateScriptAsset(string pathName, string text) {
 			string fullPath = Path.GetFullPath(pathName);
+#pragma warning disable IDE0090 // Use 'new(...)'
 			UTF8Encoding encoding = new UTF8Encoding(true, false);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			bool append = false;
+#pragma warning disable IDE0090 // Use 'new(...)'
 			StreamWriter streamWriter = new StreamWriter(fullPath, append, encoding);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			streamWriter.Write(text);
 			streamWriter.Close();
 			AssetDatabase.ImportAsset(pathName);
@@ -175,7 +181,9 @@ namespace Ink.UnityIntegration {
 			string fullPathName = EditorUtility.SaveFilePanel("Save Story State", defaultPath, name, "json");
 			if(fullPathName == "") 
 				return null;
+#pragma warning disable IDE0090 // Use 'new(...)'
 			using (StreamWriter outfile = new StreamWriter(fullPathName)) {
+#pragma warning restore IDE0090 // Use 'new(...)'
 				outfile.Write(jsonStoryState);
 			}
 			string relativePath = AbsoluteToUnityRelativePath(fullPathName);

--- a/Packages/Ink/Editor/Core/InkEditorUtils.cs
+++ b/Packages/Ink/Editor/Core/InkEditorUtils.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿#pragma warning disable IDE1006
+
+using UnityEngine;
 using UnityEditor;
 using System;
 using System.Collections.Generic;

--- a/Packages/Ink/Editor/Core/InkEditorUtils.cs
+++ b/Packages/Ink/Editor/Core/InkEditorUtils.cs
@@ -230,7 +230,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		public static bool CheckStoryStateIsValid (string storyJSON, string storyStateJSON) {
+#pragma warning disable IDE0018 // Inline variable declaration
 			Story story;
+#pragma warning restore IDE0018 // Inline variable declaration
 			if(CheckStoryIsValid(storyJSON, out story)) {
 				try {
 					story.state.LoadJson(storyStateJSON);

--- a/Packages/Ink/Editor/Tools/Build Validation/InkPreBuildValidationCheck.cs
+++ b/Packages/Ink/Editor/Tools/Build Validation/InkPreBuildValidationCheck.cs
@@ -34,7 +34,9 @@ IPreprocessBuild
 
     static void AssertNotCompiling () {
         if(InkCompiler.compiling) {
+#pragma warning disable IDE0090 // Use 'new(...)'
             StringBuilder sb = new StringBuilder("Ink is currently compiling!");
+#pragma warning restore IDE0090 // Use 'new(...)'
             var errorString = sb.ToString();
             InkCompiler.buildBlocked = true;
             if(UnityEditor.EditorUtility.DisplayDialog("Ink Build Error!", errorString, "Ok")) {
@@ -46,7 +48,9 @@ IPreprocessBuild
     static void CheckForInvalidFiles () {
         var filesToRecompile = InkLibrary.GetFilesRequiringRecompile();
         if(filesToRecompile.Any()) {
+#pragma warning disable IDE0090 // Use 'new(...)'
             StringBuilder sb = new StringBuilder();
+#pragma warning restore IDE0090 // Use 'new(...)'
             sb.AppendLine("There are Ink files which should be compiled, but appear not to be. You can resolve this by either:");
             sb.AppendLine(" - Compiling your files via 'Assets/Recompile Ink'");
             var resolveStep = " - Disabling 'Compile Automatically' "+(InkSettings.instance.compileAutomatically ? "in your Ink Settings file" : "for each of the files listed below");

--- a/Packages/Ink/Editor/Tools/File Icons/InkBrowserIcons.cs
+++ b/Packages/Ink/Editor/Tools/File Icons/InkBrowserIcons.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿#pragma warning disable IDE1006
+
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 

--- a/Packages/Ink/Editor/Tools/File Icons/InkBrowserIcons.cs
+++ b/Packages/Ink/Editor/Tools/File Icons/InkBrowserIcons.cs
@@ -138,7 +138,9 @@ namespace Ink.UnityIntegration {
 			if(inkFileIconLarge != null)
 				GUI.DrawTexture(rect, inkFileIconLarge);
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			Rect miniRect = new Rect(rect.center, rect.size * 0.5f);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			if(inkFile == null) {
 				if(unknownFileIcon != null) {
 					GUI.DrawTexture(miniRect, unknownFileIcon);
@@ -169,7 +171,9 @@ namespace Ink.UnityIntegration {
 				if(!InkSettings.instance.compileAutomatically && !inkFile.compileAutomatically && inkFile.isMaster)
 					GUI.DrawTexture(new Rect(rect.x, rect.y + rect.size.y * 0.5f, rect.size.x * 0.5f, rect.size.y * 0.5f), manualIcon);
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect miniRect = new Rect(rect.center, rect.size * 0.5f);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				if(inkFile.hasErrors && errorIcon != null) {
 					GUI.DrawTexture(miniRect, errorIcon);
 				} else if(inkFile.hasWarnings && warningIcon != null) {

--- a/Packages/Ink/Editor/Tools/Ink Inspector/DefaultAssetEditor.cs
+++ b/Packages/Ink/Editor/Tools/Ink Inspector/DefaultAssetEditor.cs
@@ -10,7 +10,9 @@ namespace Ink.UnityIntegration {
 
 		private DefaultAssetInspector inspector;
 
+#pragma warning disable IDE0051 // Remove unused private members
 		private void OnEnable () {
+#pragma warning restore IDE0051 // Remove unused private members
 			inspector = FindObjectInspector ();
 			if(inspector != null) {
 				inspector.editor = this;
@@ -20,7 +22,9 @@ namespace Ink.UnityIntegration {
 			}
 		}
 
+#pragma warning disable IDE0051 // Remove unused private members
 		private void OnDisable () {
+#pragma warning restore IDE0051 // Remove unused private members
 			if(inspector != null)
 				inspector.OnDisable();
 		}

--- a/Packages/Ink/Editor/Tools/Ink Inspector/InkInspector.cs
+++ b/Packages/Ink/Editor/Tools/Ink Inspector/InkInspector.cs
@@ -106,7 +106,9 @@ namespace Ink.UnityIntegration {
 
 		void CreateIncludeList () {
 			List<DefaultAsset> includeTextAssets = inkFile.includes;
+#pragma warning disable IDE0017 // Simplify object initialization
 			includesFileList = new ReorderableList(includeTextAssets, typeof(DefaultAsset), false, false, false, false);
+#pragma warning restore IDE0017 // Simplify object initialization
 			includesFileList.drawHeaderCallback = (Rect rect) => {  
 				EditorGUI.LabelField(rect, "Included Files");
 			};
@@ -151,7 +153,9 @@ namespace Ink.UnityIntegration {
 
 		void CreateMastersList () {
 			List<DefaultAsset> mastersTextAssets = inkFile.masterInkAssets;
+#pragma warning disable IDE0017 // Simplify object initialization
 			mastersFileList = new ReorderableList(mastersTextAssets, typeof(DefaultAsset), false, false, false, false);
+#pragma warning restore IDE0017 // Simplify object initialization
 			mastersFileList.drawHeaderCallback = (Rect rect) => {  
 				EditorGUI.LabelField(rect, "Master Files");
 			};
@@ -212,7 +216,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		void CreateErrorList () {
+#pragma warning disable IDE0017 // Simplify object initialization
 			errorList = new ReorderableList(inkFile.errors, typeof(string), false, false, false, false);
+#pragma warning restore IDE0017 // Simplify object initialization
 			errorList.elementHeight = 18;
 			errorList.drawHeaderCallback = (Rect rect) => {  
 				EditorGUI.LabelField(rect, new GUIContent(InkBrowserIcons.errorIcon), new GUIContent("Errors"));
@@ -235,7 +241,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		void CreateWarningList () {
+#pragma warning disable IDE0017 // Simplify object initialization
 			warningList = new ReorderableList(inkFile.warnings, typeof(string), false, false, false, false);
+#pragma warning restore IDE0017 // Simplify object initialization
 			warningList.elementHeight = 18;
 			warningList.drawHeaderCallback = (Rect rect) => {  
 				EditorGUI.LabelField(rect, new GUIContent(InkBrowserIcons.warningIcon), new GUIContent("Warnings"));
@@ -258,7 +266,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		void CreateTodoList () {
+#pragma warning disable IDE0017 // Simplify object initialization
 			todosList = new ReorderableList(inkFile.todos, typeof(string), false, false, false, false);
+#pragma warning restore IDE0017 // Simplify object initialization
 			todosList.elementHeight = 18;
 			todosList.drawHeaderCallback = (Rect rect) => {  
 				EditorGUI.LabelField(rect, "To do");

--- a/Packages/Ink/Editor/Tools/Ink Inspector/InkInspector.cs
+++ b/Packages/Ink/Editor/Tools/Ink Inspector/InkInspector.cs
@@ -45,17 +45,25 @@ namespace Ink.UnityIntegration {
 			GUILayout.EndHorizontal();
 
 			Rect lastRect = GUILayoutUtility.GetLastRect();
+#pragma warning disable IDE0090 // Use 'new(...)'
 			Rect rect = new Rect(lastRect.x, lastRect.y, lastRect.width, lastRect.height);
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			Rect iconRect = new Rect(rect.x + 6f, rect.y + 6f, 32f, 32f);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			GUI.DrawTexture(iconRect, InkBrowserIcons.inkFileIconLarge);
+#pragma warning disable IDE0090 // Use 'new(...)'
 			Rect childIconRect = new Rect(iconRect.x, iconRect.y, 16f, 16f);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			if(inkFile == null) {
 				GUI.DrawTexture(childIconRect, InkBrowserIcons.unknownFileIcon, ScaleMode.ScaleToFit);
 			} else if(!inkFile.isMaster) {
 				GUI.DrawTexture(childIconRect, InkBrowserIcons.childIconLarge, ScaleMode.ScaleToFit);
 			}
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			Rect titleRect = new Rect(rect.x + 44f, rect.y + 6f, rect.width - 44f - 38f - 4f, 16f);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			titleRect.yMin -= 2f;
 			titleRect.yMax += 2f;
 			GUI.Label(titleRect, editor.target.name, EditorStyles.largeLabel);
@@ -115,12 +123,18 @@ namespace Ink.UnityIntegration {
 					EditorGUI.LabelField(rect, new GUIContent("Warning: Ink File for included file "+childAssetFile+" not found. Use Assets > Recompile Ink to fix this issue."));
 					return;
 				}
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect iconRect = new Rect(rect.x, rect.y, 0, 16);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				if(childInkFile.hasErrors || childInkFile.hasWarnings) {
 					iconRect.width = 20;
 				}
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect objectFieldRect = new Rect(iconRect.xMax, rect.y, rect.width - iconRect.width - 80, 16);
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect selectRect = new Rect(objectFieldRect.xMax, rect.y, 80, 16);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				if(childInkFile.hasErrors) {
 					EditorGUI.LabelField(iconRect, new GUIContent(InkBrowserIcons.errorIcon));
 				} else if(childInkFile.hasWarnings) {
@@ -154,12 +168,18 @@ namespace Ink.UnityIntegration {
 					EditorGUI.LabelField(rect, new GUIContent("Warning: Ink File for master file "+masterAssetFile+" not found. Use Assets > Recompile Ink to fix this issue."));
 					return;
 				}
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect iconRect = new Rect(rect.x, rect.y, 0, 16);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				if(masterInkFile.hasErrors || masterInkFile.hasWarnings) {
 					iconRect.width = 20;
 				}
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect objectFieldRect = new Rect(iconRect.xMax, rect.y, rect.width - iconRect.width - 80, 16);
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect selectRect = new Rect(objectFieldRect.xMax, rect.y, 80, 16);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				if(masterInkFile.hasErrors) {
 					EditorGUI.LabelField(iconRect, new GUIContent(InkBrowserIcons.errorIcon));
 				} else if(masterInkFile.hasWarnings) {
@@ -198,8 +218,12 @@ namespace Ink.UnityIntegration {
 				EditorGUI.LabelField(rect, new GUIContent(InkBrowserIcons.errorIcon), new GUIContent("Errors"));
 			};
 			errorList.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) => {
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect labelRect = new Rect(rect.x, rect.y, rect.width - 80, rect.height);
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect buttonRect = new Rect(labelRect.xMax, rect.y, 80, rect.height-2);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				InkCompilerLog log = ((List<InkCompilerLog>)errorList.list)[index];
 				string label = log.content;
 				GUI.Label(labelRect, label);
@@ -217,8 +241,12 @@ namespace Ink.UnityIntegration {
 				EditorGUI.LabelField(rect, new GUIContent(InkBrowserIcons.warningIcon), new GUIContent("Warnings"));
 			};
 			warningList.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) => {
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect labelRect = new Rect(rect.x, rect.y, rect.width - 80, rect.height);
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect buttonRect = new Rect(labelRect.xMax, rect.y, 80, rect.height-2);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				InkCompilerLog log = ((List<InkCompilerLog>)warningList.list)[index];
 				string label = log.content;
 				GUI.Label(labelRect, label);
@@ -236,8 +264,12 @@ namespace Ink.UnityIntegration {
 				EditorGUI.LabelField(rect, "To do");
 			};
 			todosList.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) => {
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect labelRect = new Rect(rect.x, rect.y, rect.width - 80, rect.height);
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect buttonRect = new Rect(labelRect.xMax, rect.y, 80, rect.height-2);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				InkCompilerLog log = ((List<InkCompilerLog>)todosList.list)[index];
 				string label = log.content;
 				GUI.Label(labelRect, label);

--- a/Packages/Ink/Editor/Tools/Player Window/InkHistoryContentItem.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkHistoryContentItem.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using Ink.Runtime;
 using UnityEngine;

--- a/Packages/Ink/Editor/Tools/Player Window/InkHistoryContentItem.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkHistoryContentItem.cs
@@ -79,7 +79,9 @@ namespace Ink.UnityIntegration.Debugging {
                 return DateTime.FromFileTime(jdt.value);
             }
             public static implicit operator JsonDateTime(DateTime dt) {
+#pragma warning disable IDE0090 // Use 'new(...)'
                 JsonDateTime jdt = new JsonDateTime();
+#pragma warning restore IDE0090 // Use 'new(...)'
                 jdt.value = dt.ToFileTime();
                 return jdt;
             }

--- a/Packages/Ink/Editor/Tools/Player Window/InkHistoryContentItem.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkHistoryContentItem.cs
@@ -80,7 +80,9 @@ namespace Ink.UnityIntegration.Debugging {
             }
             public static implicit operator JsonDateTime(DateTime dt) {
 #pragma warning disable IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0017 // Simplify object initialization
                 JsonDateTime jdt = new JsonDateTime();
+#pragma warning restore IDE0017 // Simplify object initialization
 #pragma warning restore IDE0090 // Use 'new(...)'
                 jdt.value = dt.ToFileTime();
                 return jdt;

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -1851,7 +1851,9 @@ namespace Ink.UnityIntegration {
                         var newPath = currentPath.Length == 0 ? contentKVP.Key : currentPath+"."+contentKVP.Key;
                         AddContent(newPath, contentKVP, indent);
                     }
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                     indent--;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
                     if(lastTotalHeight != totalHeight) totalHeight += indentChangeVerticalSpacing;
                 }
                 void AddContent (string currentPath, KeyValuePair<string, Runtime.Object> contentKVP, int indent = 0) {
@@ -1984,7 +1986,9 @@ namespace Ink.UnityIntegration {
 			if (GUILayout.Button(new GUIContent("Execute", "Runs the function"))) {
 				AddToHistory(InkHistoryContentItem.CreateForDebugNote("Execute function '"+InkPlayerWindowState.Instance.functionPanelState.functionParams.functionName+"'"));
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
 				string outputContent = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
 				object[] allInput = new object[InkPlayerWindowState.Instance.functionPanelState.functionParams.inputs.Count];
 				for (int i = 0; i < InkPlayerWindowState.Instance.functionPanelState.functionParams.inputs.Count; i++) {

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -138,7 +138,9 @@ namespace Ink.UnityIntegration {
 			} 
 			public static InkPlayerParams ForAttachedStories {
 				get {
+#pragma warning disable IDE0017 // Simplify object initialization
 					var inkPlayerParams = new InkPlayerParams();
+#pragma warning restore IDE0017 // Simplify object initialization
 					inkPlayerParams.disablePlayControls = true;
 					inkPlayerParams.disableUndoHistory = true;
 					inkPlayerParams.disableChoices = true;
@@ -805,7 +807,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		static void PlayInternal () {
+#pragma warning disable IDE0017 // Simplify object initialization
 			story = new Story(storyJSON);
+#pragma warning restore IDE0017 // Simplify object initialization
 			story.allowExternalFunctionFallbacks = true;
 		}
 
@@ -1906,7 +1910,9 @@ namespace Ink.UnityIntegration {
 				var hadError = false;
                 try {
                     // We might optimise this by caching story.ToJson() - we could use this in other places too.
+#pragma warning disable IDE0017 // Simplify object initialization
                     var tmpStory = new Story(story.ToJson());
+#pragma warning restore IDE0017 // Simplify object initialization
 			        tmpStory.allowExternalFunctionFallbacks = true;
                     var state = story.state.ToJson();
                     tmpStory.state.LoadJson(state);
@@ -1977,7 +1983,9 @@ namespace Ink.UnityIntegration {
 			EditorGUI.BeginDisabledGroup(!functionIsValid);
 			if (GUILayout.Button(new GUIContent("Execute", "Runs the function"))) {
 				AddToHistory(InkHistoryContentItem.CreateForDebugNote("Execute function '"+InkPlayerWindowState.Instance.functionPanelState.functionParams.functionName+"'"));
+#pragma warning disable IDE0018 // Inline variable declaration
 				string outputContent = null;
+#pragma warning restore IDE0018 // Inline variable declaration
 				object[] allInput = new object[InkPlayerWindowState.Instance.functionPanelState.functionParams.inputs.Count];
 				for (int i = 0; i < InkPlayerWindowState.Instance.functionPanelState.functionParams.inputs.Count; i++) {
 					var input = InkPlayerWindowState.Instance.functionPanelState.functionParams.inputs[i];
@@ -2045,7 +2053,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		void BuildFunctionInputList () {
+#pragma warning disable IDE0017 // Simplify object initialization
 			functionInputList = new ReorderableList(InkPlayerWindowState.Instance.functionPanelState.functionParams.inputs, typeof(FunctionPanelState.FunctionParams.FunctionInput), true, true, true, true);
+#pragma warning restore IDE0017 // Simplify object initialization
 			functionInputList.drawHeaderCallback = (Rect rect) => {
 				EditorGUI.LabelField(rect, "Inputs");
 			};

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -2786,7 +2786,9 @@ namespace Ink.UnityIntegration {
 		public virtual T Undo () {
 			if(!canUndo) {
 				if(undoHistory.Count > 0)
+#pragma warning disable IDE0034 // Simplify 'default' expression
 					return default(T);
+#pragma warning restore IDE0034 // Simplify 'default' expression
 			} else {
 				undoHistoryIndex--;
 #pragma warning disable IDE1005 // Delegate invocation can be simplified.
@@ -2799,7 +2801,9 @@ namespace Ink.UnityIntegration {
 		public virtual T Redo () {
 			if(!canRedo) {
 				if(undoHistory.Count > 0)
+#pragma warning disable IDE0034 // Simplify 'default' expression
 					return default(T);
+#pragma warning restore IDE0034 // Simplify 'default' expression
 			} else {
 				undoHistoryIndex++;
 #pragma warning disable IDE1005 // Delegate invocation can be simplified.

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿#pragma warning disable IDE1006
+
+using UnityEngine;
 using UnityEditorInternal;
 using UnityEditor;
 using System;

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -1245,7 +1245,9 @@ namespace Ink.UnityIntegration {
                 if(GetShouldAutoScrollOnStoryChange())
 				    ScrollToBottom();
 			}
+#pragma warning disable IDE0062 // Make local function 'static'
             void DrawVisibilityOptions () {
+#pragma warning restore IDE0062 // Make local function 'static'
                 var lw = EditorGUIUtility.labelWidth;
                 var visibilityOptionsGUIContent = EditorGUIUtility.IconContent("d_ViewToolOrbit");
                 visibilityOptionsGUIContent.tooltip = "Visiblity Options";

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -552,7 +552,9 @@ namespace Ink.UnityIntegration {
         // var jsonStr = story.ToJson ();
         // https://docs.microsoft.com/en-us/dotnet/api/system.io.path.gettemppath
         // Directory.temporaryFolder
+#pragma warning disable IDE0051 // Remove unused private members
 		void OnEnable () {
+#pragma warning restore IDE0051 // Remove unused private members
 			if(isOpen) return;
 			isOpen = true;
 
@@ -577,20 +579,28 @@ namespace Ink.UnityIntegration {
 			}
 		}
 
+#pragma warning disable IDE0051 // Remove unused private members
 		void OnDisable () {
+#pragma warning restore IDE0051 // Remove unused private members
 			EditorApplication.update -= Update;
 		}
 
+#pragma warning disable IDE0051 // Remove unused private members
 		private void OnBecameVisible() {
+#pragma warning restore IDE0051 // Remove unused private members
 			if(doingAutoscroll) {
 				InkPlayerWindowState.Instance.storyPanelState.scrollPosition = new Vector2(InkPlayerWindowState.Instance.storyPanelState.scrollPosition.x, autoscrollTarget);
 				doingAutoscroll = false;
 			}
 		}
 	
+#pragma warning disable IDE0051 // Remove unused private members
 		private void OnBecameInvisible() {}
+#pragma warning restore IDE0051 // Remove unused private members
 
+#pragma warning disable IDE0051 // Remove unused private members
 		void OnDestroy () {
+#pragma warning restore IDE0051 // Remove unused private members
 			isOpen = false;
 		}
 
@@ -1006,7 +1016,9 @@ namespace Ink.UnityIntegration {
 				ContinueStory();
 			// }
 		}
+#pragma warning disable IDE0051 // Remove unused private members
         void OnGUI () {
+#pragma warning restore IDE0051 // Remove unused private members
 			HandleDragAndDrop();
 			if(searchTextFieldStyle == null) searchTextFieldStyle = GUI.skin.FindStyle("ToolbarSeachTextField");
 			if(searchCancelButtonStyle == null) searchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
@@ -2617,7 +2629,9 @@ namespace Ink.UnityIntegration {
 		//     }
 		//     EditorGUILayout.EndVertical();
 		// }
+#pragma warning disable IDE0051 // Remove unused private members
 		static void EditorGUIInkListField (Rect rect, GUIContent content, InkList inkList, string variableName) {
+#pragma warning restore IDE0051 // Remove unused private members
 			EditorGUI.PrefixLabel(rect, content);
 			if(inkList.Any()) {
 				if(GUILayout.Button("Log Contents")) {

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -2017,15 +2017,25 @@ namespace Ink.UnityIntegration {
 				GUILayout.BeginVertical(GUI.skin.box);
 				if(InkPlayerWindowState.Instance.functionPanelState.functionReturnValue == null) {
 					EditorGUILayout.LabelField("Output (Null)");
+#pragma warning disable IDE0038 // Use pattern matching
 				} else if(InkPlayerWindowState.Instance.functionPanelState.functionReturnValue is string) {
+#pragma warning restore IDE0038 // Use pattern matching
 					EditorGUILayout.TextField("Output (String)", (string)InkPlayerWindowState.Instance.functionPanelState.functionReturnValue);
+#pragma warning disable IDE0038 // Use pattern matching
 				} else if(InkPlayerWindowState.Instance.functionPanelState.functionReturnValue is float) {
+#pragma warning restore IDE0038 // Use pattern matching
 					EditorGUILayout.FloatField("Output (Float)", (float)InkPlayerWindowState.Instance.functionPanelState.functionReturnValue);
+#pragma warning disable IDE0038 // Use pattern matching
 				} else if(InkPlayerWindowState.Instance.functionPanelState.functionReturnValue is int) {
+#pragma warning restore IDE0038 // Use pattern matching
 					EditorGUILayout.IntField("Output (Int)", (int)InkPlayerWindowState.Instance.functionPanelState.functionReturnValue);
+#pragma warning disable IDE0038 // Use pattern matching
 				} else if(InkPlayerWindowState.Instance.functionPanelState.functionReturnValue is bool) {
+#pragma warning restore IDE0038 // Use pattern matching
 					EditorGUILayout.Toggle("Output (Bool)", (bool)InkPlayerWindowState.Instance.functionPanelState.functionReturnValue);
+#pragma warning disable IDE0038 // Use pattern matching
 				} else if(InkPlayerWindowState.Instance.functionPanelState.functionReturnValue is InkList) {
+#pragma warning restore IDE0038 // Use pattern matching
 					EditorGUILayoutInkListField(new GUIContent("Output (InkList)"), (InkList)InkPlayerWindowState.Instance.functionPanelState.functionReturnValue);
 				} else {
 					EditorGUILayout.LabelField("Function returned unexpected type "+InkPlayerWindowState.Instance.functionPanelState.functionReturnValue.GetType().Name+".");
@@ -2221,29 +2231,41 @@ namespace Ink.UnityIntegration {
 			var lastVariableValue = variableValue;
             var anythingChanged = false;
             EditorGUILayout.BeginHorizontal();
+#pragma warning disable IDE0038 // Use pattern matching
 			if(variableValue is string) {
+#pragma warning restore IDE0038 // Use pattern matching
 				EditorGUI.BeginDisabledGroup(playerParams.disableSettingVariables);
 				variableValue = EditorGUILayout.DelayedTextField(guiContent, (string)variableValue);
                 anythingChanged = lastVariableValue != variableValue;
 				EditorGUI.EndDisabledGroup();
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is float) {
+#pragma warning restore IDE0038 // Use pattern matching
 				EditorGUI.BeginDisabledGroup(playerParams.disableSettingVariables);
 				variableValue = EditorGUILayout.FloatField(guiContent, (float)variableValue);
                 anythingChanged = lastVariableValue != variableValue;
 				EditorGUI.EndDisabledGroup();
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is int) {
+#pragma warning restore IDE0038 // Use pattern matching
 				EditorGUI.BeginDisabledGroup(playerParams.disableSettingVariables);
 				variableValue = EditorGUILayout.IntField(guiContent, (int)variableValue);
                 anythingChanged = lastVariableValue != variableValue;
 				EditorGUI.EndDisabledGroup();
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is bool) {
+#pragma warning restore IDE0038 // Use pattern matching
 				EditorGUI.BeginDisabledGroup(playerParams.disableSettingVariables);
 				variableValue = EditorGUILayout.Toggle(guiContent, (bool)variableValue);
                 anythingChanged = lastVariableValue != variableValue;
 				EditorGUI.EndDisabledGroup();
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is InkList) {
+#pragma warning restore IDE0038 // Use pattern matching
 				anythingChanged = EditorGUILayoutInkListField(guiContent, (InkList)variableValue, variableName+expandedIDModifier);
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is Ink.Runtime.Path) {
+#pragma warning restore IDE0038 // Use pattern matching
 				var c = new GUIContent(((Ink.Runtime.Path)variableValue).ToString()+" (Ink.Runtime.Path)");
 				EditorGUILayout.LabelField(guiContent, c);
 			} else if(variableValue == null) {
@@ -2256,13 +2278,21 @@ namespace Ink.UnityIntegration {
 		}
 
 		object DrawVariable (Rect rect, GUIContent variable, object variableValue) {
+#pragma warning disable IDE0038 // Use pattern matching
 			if(variableValue is string) {
+#pragma warning restore IDE0038 // Use pattern matching
 				variableValue = EditorGUI.TextField(rect, variable, (string)variableValue);
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is float) {
+#pragma warning restore IDE0038 // Use pattern matching
 				variableValue = EditorGUI.FloatField(rect, variable, (float)variableValue);
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is int) {
+#pragma warning restore IDE0038 // Use pattern matching
 				variableValue = EditorGUI.IntField(rect, variable, (int)variableValue);
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is InkList) {
+#pragma warning restore IDE0038 // Use pattern matching
 				var c = new GUIContent(variable);
 				var inkList = (InkList)variableValue;
 				c.text += " (InkList)";
@@ -2277,7 +2307,9 @@ namespace Ink.UnityIntegration {
 					c.text += " Empty";
 				}
 				EditorGUI.LabelField(rect, c);
+#pragma warning disable IDE0038 // Use pattern matching
 			} else if(variableValue is Ink.Runtime.Path) {
+#pragma warning restore IDE0038 // Use pattern matching
 				var c = new GUIContent(((Ink.Runtime.Path)variableValue).ToString()+" (Ink.Runtime.Path)");
 				EditorGUI.LabelField(rect, c);
 			} else if(variableValue == null) {
@@ -2600,7 +2632,9 @@ namespace Ink.UnityIntegration {
 			public DateTime dateTime;
 			public ObservedVariableState (object state) {
 				// Make sure to clone any object ref types! (just InkList at time of writing)
+#pragma warning disable IDE0038 // Use pattern matching
 				if(state is InkList) state = new InkList((InkList)state);
+#pragma warning restore IDE0038 // Use pattern matching
 				this.state = state;
 				dateTime = DateTime.Now;
 			}

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -198,7 +198,9 @@ namespace Ink.UnityIntegration {
 			public static void CreateAndSave () {
 				_Instance = new InkPlayerWindowState();
 				Save(_Instance);
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
 				if(OnCreateOrLoad != null) OnCreateOrLoad();
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 			}
 			
 			public static void Save () {
@@ -215,7 +217,9 @@ namespace Ink.UnityIntegration {
 				string data = EditorPrefs.GetString(settingsEditorPrefsKey);
 				try {
 					_Instance = JsonUtility.FromJson<InkPlayerWindowState>(data);
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
 					if(_Instance != null) if(OnCreateOrLoad != null) OnCreateOrLoad();
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 				} catch {
 					Debug.LogError("Save Data was corrupt and could not be parsed. New data created. Old data was:\n"+data);
 					CreateAndSave();
@@ -797,7 +801,9 @@ namespace Ink.UnityIntegration {
 			_story.onChoosePathString += OnChoosePathString;
 			_story.state.onDidLoadState += OnLoadState;
 
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
             if(OnDidSetStory != null) OnDidSetStory(story);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 			
 			// Recalculate function ink variables
 			foreach(var input in InkPlayerWindowState.Instance.functionPanelState.functionParams.inputs) {
@@ -2571,7 +2577,9 @@ namespace Ink.UnityIntegration {
 				return _undoHistoryIndex;
 			} set {
 				_undoHistoryIndex = Mathf.Clamp(value, 0, undoHistory.Count-1);
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
 				if(OnChangeHistoryIndex != null) OnChangeHistoryIndex(undoHistory[undoHistoryIndex]);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 			}
 		}
 		
@@ -2624,13 +2632,17 @@ namespace Ink.UnityIntegration {
 			undoHistory.Add (state);
 			_undoHistoryIndex++;
 			
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
 			if(OnChangeUndoHistory != null) OnChangeUndoHistory();
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 		}
 		
 		public virtual void Clear () {
 			undoHistory.Clear();
 			_undoHistoryIndex = -1;
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
 			if(OnChangeUndoHistory != null) OnChangeUndoHistory();
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 		}
 		
 		public virtual T Undo () {
@@ -2639,7 +2651,9 @@ namespace Ink.UnityIntegration {
 					return default(T);
 			} else {
 				undoHistoryIndex--;
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
 				if(OnUndo != null) OnUndo(undoHistory[undoHistoryIndex]);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 			}
 			return undoHistory[undoHistoryIndex];
 		}
@@ -2650,7 +2664,9 @@ namespace Ink.UnityIntegration {
 					return default(T);
 			} else {
 				undoHistoryIndex++;
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
 				if(OnRedo != null) OnRedo(undoHistory[undoHistoryIndex]);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
 			}
 			return undoHistory[undoHistoryIndex];
 		}

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -2546,7 +2546,9 @@ namespace Ink.UnityIntegration {
 		static bool EditorGUILayoutInkListField (GUIContent guiContent, InkList inkList, string expandedVariableKey = null) {
 			var anythingChanged = false;
             // if(inkList.Any()) {
+#pragma warning disable IDE0075 // Simplify conditional expression
 				var show = expandedVariableKey == null ? true : InkPlayerWindowState.Instance.variablesPanelState.expandedVariables.Contains(expandedVariableKey);
+#pragma warning restore IDE0075 // Simplify conditional expression
 				var c = new GUIContent(guiContent);
 				c.text += " (InkList with "+inkList.Count+" entries)";
 				EditorGUILayout.BeginVertical();

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -179,7 +179,9 @@ namespace Ink.UnityIntegration {
 
 		[System.Serializable]
 		public class InkPlayerWindowState {
+#pragma warning disable IDE0044 // Add readonly modifier
 			static string settingsEditorPrefsKey = typeof(InkPlayerWindowState).Name +" Settings";
+#pragma warning restore IDE0044 // Add readonly modifier
 			public static event Action OnCreateOrLoad;
 			static InkPlayerWindowState _Instance;
 			public static InkPlayerWindowState Instance {
@@ -306,7 +308,9 @@ namespace Ink.UnityIntegration {
 			}
 		}
 		
+#pragma warning disable IDE0044 // Add readonly modifier
 		private static UndoHistory<InkPlayerHistoryItem> storyStateHistory = new UndoHistory<InkPlayerHistoryItem>();
+#pragma warning restore IDE0044 // Add readonly modifier
 		private static List<InkHistoryContentItem> storyHistory = new List<InkHistoryContentItem>();
 
 		
@@ -482,7 +486,9 @@ namespace Ink.UnityIntegration {
 		static bool doingAutoscroll;
 		static float autoscrollTarget;
 		static float autoscrollVelocity;
+#pragma warning disable IDE0044 // Add readonly modifier
 		static float autoscrollSmoothTime = 0.225f;
+#pragma warning restore IDE0044 // Add readonly modifier
 
 
 
@@ -1271,7 +1277,9 @@ namespace Ink.UnityIntegration {
 			return false;
 		}
 		
+#pragma warning disable IDE0044 // Add readonly modifier
 		static List<InkHistoryContentItem> visibleHistory = new List<InkHistoryContentItem>();
+#pragma warning restore IDE0044 // Add readonly modifier
 		static void RefreshVisibleHistory () {
 			visibleHistory.Clear();
 			bool doingSearch = !string.IsNullOrWhiteSpace(InkPlayerWindowState.Instance.storyPanelState.searchString);
@@ -2077,7 +2085,9 @@ namespace Ink.UnityIntegration {
 			GUILayout.EndVertical();
 		}
 
+#pragma warning disable IDE0044 // Add readonly modifier
         static List<string> visibleVariables = new List<string>();
+#pragma warning restore IDE0044 // Add readonly modifier
 		static void RefreshVisibleVariables () {
 			visibleVariables.Clear();
             if(story == null) return;

--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -159,12 +159,16 @@ namespace Ink.UnityIntegration {
 			public float continueAutomaticallyTimeInterval = 0.1f;
 			public float chooseAutomaticallyTimeInterval = 0.1f;
 		}
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public static PlayerOptions playerOptions = new PlayerOptions();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
 
         // Allows injecting right click context options into the story content view.
         public delegate void ContextMenuDelegate(GenericMenu contextMenu, InkHistoryContentItem content);
+#pragma warning disable IDE0090 // Use 'new(...)'
         public static List<ContextMenuDelegate> contextMenuDelegates = new List<ContextMenuDelegate>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
         #endregion
 
@@ -240,16 +244,34 @@ namespace Ink.UnityIntegration {
 				return asset;
 			}
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public StoryPanelState storyPanelState = new StoryPanelState() {showing=true};
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public BaseStoryPanelState choicePanelState = new BaseStoryPanelState() {showing=true};
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public DivertPanelState divertPanelState = new DivertPanelState();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public NamedContentPanelState namedContentPanelState = new NamedContentPanelState();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public FunctionPanelState functionPanelState = new FunctionPanelState();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			// public FunctionPanelState.FunctionParams functionParams = new FunctionPanelState.FunctionParams();
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public VariablesPanelState variablesPanelState = new VariablesPanelState();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public ObservedVariablesPanelState observedVariablesPanelState = new ObservedVariablesPanelState();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public BaseStoryPanelState saveLoadPanelState = new BaseStoryPanelState();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public BaseStoryPanelState profilerPanelState = new BaseStoryPanelState();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		}
 
 		
@@ -309,9 +331,13 @@ namespace Ink.UnityIntegration {
 		}
 		
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		private static UndoHistory<InkPlayerHistoryItem> storyStateHistory = new UndoHistory<InkPlayerHistoryItem>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		private static List<InkHistoryContentItem> storyHistory = new List<InkHistoryContentItem>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
 		
 		private static Exception playStoryException;
@@ -356,7 +382,9 @@ namespace Ink.UnityIntegration {
 
 		[System.Serializable]
 		public class StoryPanelState : BaseStoryPanelState {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public DisplayOptions displayOptions = new DisplayOptions();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			public string searchString = string.Empty;
 			
 			public const float minScrollRectHeight = 30;
@@ -418,9 +446,13 @@ namespace Ink.UnityIntegration {
 					}
 				}
 				public string functionName = String.Empty;
+#pragma warning disable IDE0090 // Use 'new(...)'
 				public List<FunctionInput> inputs = new List<FunctionInput>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			}
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public FunctionParams functionParams = new FunctionParams();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			public string testedFunctionName = null;
 			public object functionReturnValue = null;
 		}
@@ -428,11 +460,17 @@ namespace Ink.UnityIntegration {
 		[System.Serializable]
 		public class VariablesPanelState : BaseStoryPanelState {
 			public string searchString = string.Empty;
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public List<string> expandedVariables = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		}
 		public class ObservedVariablesPanelState : BaseStoryPanelState {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public List<string> observedVariableNames = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			public Dictionary<string, ObservedVariable> observedVariables = new Dictionary<string, ObservedVariable>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		}
 
 		[System.Serializable]
@@ -602,7 +640,9 @@ namespace Ink.UnityIntegration {
 			AddWarningsAndErrorsToHistory();
 		}
 		static void OnEvaluateFunction (string functionName, object[] arguments) {
+#pragma warning disable IDE0090 // Use 'new(...)'
             StringBuilder sb = new StringBuilder(functionName);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			if(arguments != null && arguments.Length > 0) {
 				sb.Append(" with args: ");
 				for (int i = 0; i < arguments.Length; i++) {
@@ -620,7 +660,9 @@ namespace Ink.UnityIntegration {
 			AddWarningsAndErrorsToHistory();
 		}
 		static void OnCompleteEvaluateFunction (string functionName, object[] arguments, string textOutput, object result) {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			StringBuilder sb = new StringBuilder(functionName);
+#pragma warning restore IDE0090 // Use 'new(...)'
 			if(arguments != null && arguments.Length > 0) {
 				sb.Append(" with args: ");
 				for (int i = 0; i < arguments.Length; i++) {
@@ -642,7 +684,9 @@ namespace Ink.UnityIntegration {
 			AddWarningsAndErrorsToHistory();
 		}
 		static void OnChoosePathString (string pathString, object[] arguments) {
+#pragma warning disable IDE0090 // Use 'new(...)'
             StringBuilder sb = new StringBuilder("ChoosePathString: ");
+#pragma warning restore IDE0090 // Use 'new(...)'
 			sb.Append(pathString);
 			if(arguments != null) {
 				sb.Append(" with args: ");
@@ -887,7 +931,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		static void AddToStateHistory () {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			InkPlayerHistoryItem historyItem = new InkPlayerHistoryItem(story.state.ToJson(), new List<InkHistoryContentItem>(storyHistory));
+#pragma warning restore IDE0090 // Use 'new(...)'
 			storyStateHistory.AddToUndoHistory(historyItem);
 		}
 		
@@ -1231,7 +1277,9 @@ namespace Ink.UnityIntegration {
         }
 
 		void CopyStoryHistoryToClipboard () {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			StringBuilder sb = new StringBuilder("Story Log\n");
+#pragma warning restore IDE0090 // Use 'new(...)'
 			foreach(InkHistoryContentItem content in storyHistory) {
 				sb.AppendLine();
 				sb.Append(content.time.ToShortDateString());
@@ -1278,7 +1326,9 @@ namespace Ink.UnityIntegration {
 		}
 		
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		static List<InkHistoryContentItem> visibleHistory = new List<InkHistoryContentItem>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 		static void RefreshVisibleHistory () {
 			visibleHistory.Clear();
@@ -1780,8 +1830,12 @@ namespace Ink.UnityIntegration {
 			
 			float totalHeight = 0;
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<Rect> rects = new List<Rect>();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<string> paths = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
             {
                 AddContainer(string.Empty, story.mainContentContainer);
                 void AddContainer (string currentPath, Container container, int indent = 0) {
@@ -1988,9 +2042,13 @@ namespace Ink.UnityIntegration {
 			functionInputList.elementHeight = EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing * 2;
 			functionInputList.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) => {
 				var input = InkPlayerWindowState.Instance.functionPanelState.functionParams.inputs[index];
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect typeRect = new Rect(rect.x, rect.y, 80, EditorGUIUtility.singleLineHeight);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				input.type = (FunctionPanelState.FunctionParams.FunctionInput.FunctionInputType)EditorGUI.EnumPopup(typeRect, input.type);
+#pragma warning disable IDE0090 // Use 'new(...)'
 				Rect inputRect = new Rect(rect.x + 90, rect.y, rect.width - 90, EditorGUIUtility.singleLineHeight);
+#pragma warning restore IDE0090 // Use 'new(...)'
 				switch(input.type) {
 				case FunctionPanelState.FunctionParams.FunctionInput.FunctionInputType.Int:
 					input.intValue = EditorGUI.IntField(inputRect, input.intValue);
@@ -2086,7 +2144,9 @@ namespace Ink.UnityIntegration {
 		}
 
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         static List<string> visibleVariables = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 		static void RefreshVisibleVariables () {
 			visibleVariables.Clear();
@@ -2235,7 +2295,9 @@ namespace Ink.UnityIntegration {
 		}
 
 		void DrawObservedVariablesPanel () {
+#pragma warning disable IDE0090 // Use 'new(...)'
 			List<string> allToRemove = new List<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			foreach(var observedVariable in InkPlayerWindowState.Instance.observedVariablesPanelState.observedVariables) {
 				bool removeVariable = DrawObservedVariable(observedVariable.Value);
 				if(removeVariable)
@@ -2527,7 +2589,9 @@ namespace Ink.UnityIntegration {
 	public class ObservedVariable {
 		public string variable;
 		public Story.VariableObserver variableObserver;
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public List<ObservedVariableState> values = new List<ObservedVariableState>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 		public bool expanded = true;
 		public Vector2 scrollPosition = Vector2.zero;
 

--- a/Packages/Ink/Editor/Tools/Startup Window/InkUnityIntegrationStartupWindow.cs
+++ b/Packages/Ink/Editor/Tools/Startup Window/InkUnityIntegrationStartupWindow.cs
@@ -41,7 +41,9 @@ namespace Ink.UnityIntegration {
             EditorPrefs.SetInt(editorPrefsKeyForVersionSeen, announcementVersion);
         }
         
+#pragma warning disable IDE0051 // Remove unused private members
 		void OnGUI ()
+#pragma warning restore IDE0051 // Remove unused private members
 		{
 			EditorGUILayout.BeginVertical();
 			var areaSize = new Vector2(90,90);

--- a/Packages/Ink/Editor/Tools/Startup Window/InkUnityIntegrationStartupWindow.cs
+++ b/Packages/Ink/Editor/Tools/Startup Window/InkUnityIntegrationStartupWindow.cs
@@ -1,4 +1,6 @@
-﻿using UnityEditor;
+﻿#pragma warning disable IDE1006
+
+using UnityEditor;
 using UnityEngine;
 
 namespace Ink.UnityIntegration {

--- a/Packages/Ink/InkLibs/InkCompiler/CharacterRange.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/CharacterRange.cs
@@ -48,9 +48,17 @@ namespace Ink
             _excludes = excludes == null ? new HashSet<char>() : new HashSet<char> (excludes);
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         char _start;
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         char _end;
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         ICollection<char> _excludes;
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         CharacterSet _correspondingCharSet = new CharacterSet();
+#pragma warning restore IDE0044 // Add readonly modifier
     }    
 }

--- a/Packages/Ink/InkLibs/InkCompiler/CharacterRange.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/CharacterRange.cs
@@ -58,7 +58,9 @@ namespace Ink
         ICollection<char> _excludes;
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         CharacterSet _correspondingCharSet = new CharacterSet();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
     }    
 }

--- a/Packages/Ink/InkLibs/InkCompiler/CharacterRange.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/CharacterRange.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE1006
+
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
@@ -194,18 +194,26 @@ namespace Ink
                 throw new System.Exception(message);
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         string _inputString;
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         Options _options;
+#pragma warning restore IDE0044 // Add readonly modifier
 
 
         InkParser _parser;
         Parsed.Story _parsedStory;
         Runtime.Story _runtimeStory;
 
+#pragma warning disable IDE0044 // Add readonly modifier
         PluginManager _pluginManager;
+#pragma warning restore IDE0044 // Add readonly modifier
 
         bool _hadParseError;
 
+#pragma warning disable IDE0044 // Add readonly modifier
         List<DebugSourceRange> _debugSourceRanges = new List<DebugSourceRange> ();
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
@@ -109,7 +109,9 @@ namespace Ink
            // Variable assignment: create in Parsed.Story as well as the Runtime.Story
            // so that we don't get an error message during reference resolution
            if (parsedObj is Parsed.VariableAssignment) {
+#pragma warning disable IDE0020 // Use pattern matching
                var varAssign = (Parsed.VariableAssignment)parsedObj;
+#pragma warning restore IDE0020 // Use pattern matching
                if (varAssign.isNewTemporaryDeclaration) {
                    _parsedStory.TryAddNewVariableDeclaration (varAssign);
                }

--- a/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
@@ -213,7 +213,9 @@ namespace Ink
         bool _hadParseError;
 
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         List<DebugSourceRange> _debugSourceRanges = new List<DebugSourceRange> ();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using Ink;
 

--- a/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/Compiler.cs
@@ -147,7 +147,9 @@ namespace Ink
             foreach (var outputObj in _runtimeStory.state.outputStream) {
                 var textContent = outputObj as Runtime.StringValue;
                 if (textContent != null) {
+#pragma warning disable IDE0017 // Simplify object initialization
                     var range = new DebugSourceRange ();
+#pragma warning restore IDE0017 // Simplify object initialization
                     range.length = textContent.value.Length;
                     range.debugMetadata = textContent.debugMetadata;
                     range.text = textContent.value;

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/CommentEliminator.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/CommentEliminator.cs
@@ -85,9 +85,15 @@ namespace Ink
             }
         }
           
+#pragma warning disable IDE0044 // Add readonly modifier
         CharacterSet _commentOrNewlineStartCharacter = new CharacterSet ("/\r\n");
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         CharacterSet _commentBlockEndCharacter = new CharacterSet("*");
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         CharacterSet _newlineCharacters = new CharacterSet ("\n\r");
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/CommentEliminator.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/CommentEliminator.cs
@@ -86,13 +86,19 @@ namespace Ink
         }
           
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         CharacterSet _commentOrNewlineStartCharacter = new CharacterSet ("/\r\n");
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         CharacterSet _commentBlockEndCharacter = new CharacterSet("*");
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         CharacterSet _newlineCharacters = new CharacterSet ("\n\r");
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
@@ -163,11 +163,17 @@ namespace Ink
             }
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         IFileHandler _fileHandler;
+#pragma warning restore IDE0044 // Add readonly modifier
 
+#pragma warning disable IDE0044 // Add readonly modifier
         Ink.ErrorHandler _externalErrorHandler;
+#pragma warning restore IDE0044 // Add readonly modifier
 
+#pragma warning disable IDE0044 // Add readonly modifier
         string _filename;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
@@ -96,7 +96,9 @@ namespace Ink
 
         protected Runtime.DebugMetadata CreateDebugMetadata(StringParserState.Element stateAtStart, StringParserState.Element stateAtEnd)
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             var md = new Runtime.DebugMetadata ();
+#pragma warning restore IDE0017 // Simplify object initialization
             md.startLineNumber = stateAtStart.lineIndex + 1;
             md.endLineNumber = stateAtEnd.lineIndex + 1;
             md.startCharacterNumber = stateAtStart.characterInLineIndex + 1;

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
@@ -60,7 +60,9 @@ namespace Ink
             T firstElement = Parse (mainRule);
             if (firstElement == null) return null;
 
+#pragma warning disable IDE0028 // Simplify collection initialization
             var allElements = new List<T> ();
+#pragma warning restore IDE0028 // Simplify collection initialization
             allElements.Add (firstElement);
 
             do {

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE1006
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser.cs
@@ -118,7 +118,9 @@ namespace Ink
             }
 
             // A list of objects that doesn't already have metadata?
+#pragma warning disable IDE0019 // Use pattern matching
             var parsedListObjs = result as List<Parsed.Object>;
+#pragma warning restore IDE0019 // Use pattern matching
             if (parsedListObjs != null) {
                 foreach (var parsedListObj in parsedListObjs) {
                     if (!parsedListObj.hasOwnDebugMetadata) {
@@ -127,7 +129,9 @@ namespace Ink
                 }
             }
 
+#pragma warning disable IDE0019 // Use pattern matching
             var id = result as Parsed.Identifier;
+#pragma warning restore IDE0019 // Use pattern matching
             if (id != null) {
                 id.debugMetadata = CreateDebugMetadata(stateAtStart, stateAtEnd);
             }

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Choices.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Choices.cs
@@ -107,7 +107,9 @@ namespace Ink
             // the flow away permanently.
             innerContent.AddContent (new Text ("\n"));
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var choice = new Choice (startContent, optionOnlyContent, innerContent);
+#pragma warning restore IDE0017 // Simplify object initialization
             choice.identifier = optionalName;
             choice.indentationDepth = bullets.Count;
             choice.hasWeaveStyleInlineBrackets = hasWeaveStyleInlineBrackets;

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_CommandLineInput.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_CommandLineInput.cs
@@ -62,7 +62,9 @@ namespace Ink
 
             Expect (String (")"), "closing parenthesis");
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var inputStruct = new CommandLineInput ();
+#pragma warning restore IDE0017 // Simplify object initialization
             inputStruct.debugSource = characterOffset;
             return inputStruct;
         }
@@ -79,7 +81,9 @@ namespace Ink
 
             var pathStr = Expect (RuntimePath, "path") as string;
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var inputStruct = new CommandLineInput ();
+#pragma warning restore IDE0017 // Simplify object initialization
             inputStruct.debugPathLookup = pathStr;
             return inputStruct;
         }
@@ -111,7 +115,9 @@ namespace Ink
                 return null;
             }
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var inputStruct = new CommandLineInput ();
+#pragma warning restore IDE0017 // Simplify object initialization
             inputStruct.choiceInput = number;
             return inputStruct;
         }
@@ -120,7 +126,9 @@ namespace Ink
         {
             var statement = OneOf (SingleDivert, TempDeclarationOrAssignment, Expression);
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var inputStruct = new CommandLineInput ();
+#pragma warning restore IDE0017 // Simplify object initialization
             inputStruct.userImmediateModeStatement = statement;
             return inputStruct;
         }

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_CommandLineInput.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_CommandLineInput.cs
@@ -91,7 +91,9 @@ namespace Ink
         string RuntimePath ()
         {
             if (_runtimePathCharacterSet == null) {
+#pragma warning disable IDE0028 // Simplify collection initialization
                 _runtimePathCharacterSet = new CharacterSet (identifierCharSet);
+#pragma warning restore IDE0028 // Simplify collection initialization
                 _runtimePathCharacterSet.Add ('-'); // for c-0, g-0 etc
                 _runtimePathCharacterSet.Add ('.');
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_CommandLineInput.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_CommandLineInput.cs
@@ -13,7 +13,9 @@ namespace Ink
         //  - Lookup debug source for runtime path
         public CommandLineInput CommandLineUserInput()
         {
+#pragma warning disable IDE0090 // Use 'new(...)'
             CommandLineInput result = new CommandLineInput ();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
             Whitespace ();
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Conditional.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Conditional.cs
@@ -45,7 +45,9 @@ namespace Ink
                         List<Parsed.Object> soleContent = StatementsAtLevel (StatementLevel.InnerBlock);
                         if (soleContent != null) {
                             var soleBranch = new ConditionalSingleBranch (soleContent);
+#pragma warning disable IDE0028 // Simplify collection initialization
                             alternatives = new List<ConditionalSingleBranch> ();
+#pragma warning restore IDE0028 // Simplify collection initialization
                             alternatives.Add (soleBranch);
 
                             // Also allow a final "- else:" clause
@@ -242,7 +244,9 @@ namespace Ink
                 Error ("expected content for the conditional branch following '-'");
 
                 // Recover
+#pragma warning disable IDE0028 // Simplify collection initialization
                 content = new List<Ink.Parsed.Object> ();
+#pragma warning restore IDE0028 // Simplify collection initialization
                 content.Add (new Text (""));
             }
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Conditional.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Conditional.cs
@@ -69,7 +69,9 @@ namespace Ink
                 // Empty true branch - didn't get parsed, but should insert one for semantic correctness,
                 // and to make sure that any evaluation stack values get tidied up correctly.
                 else if (alternatives.Count == 1 && alternatives [0].isElse && initialQueryExpression) {
+#pragma warning disable IDE0017 // Simplify object initialization
                     var emptyTrueBranch = new ConditionalSingleBranch (null);
+#pragma warning restore IDE0017 // Simplify object initialization
                     emptyTrueBranch.isTrueBranch = true;
                     alternatives.Insert (0, emptyTrueBranch);
                 }
@@ -185,12 +187,16 @@ namespace Ink
                 Error ("Expected one or two alternatives separated by '|' in inline conditional");
             } else {
                 
+#pragma warning disable IDE0017 // Simplify object initialization
                 var trueBranch = new ConditionalSingleBranch (listOfLists[0]);
+#pragma warning restore IDE0017 // Simplify object initialization
                 trueBranch.isTrueBranch = true;
                 result.Add (trueBranch);
 
                 if (listOfLists.Count > 1) {
+#pragma warning disable IDE0017 // Simplify object initialization
                     var elseBranch = new ConditionalSingleBranch (listOfLists[1]);
+#pragma warning restore IDE0017 // Simplify object initialization
                     elseBranch.isElse = true;
                     result.Add (elseBranch);
                 }
@@ -249,7 +255,9 @@ namespace Ink
             // }
             MultilineWhitespace ();
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var branch = new ConditionalSingleBranch (content);
+#pragma warning restore IDE0017 // Simplify object initialization
             branch.ownExpression = expr;
             branch.isElse = isElse;
             return branch;

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Content.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Content.cs
@@ -182,7 +182,9 @@ namespace Ink
             }
 
             // When the ParseUntil pauses, check these rules in case they evaluate successfully
+#pragma warning disable IDE0039 // Use local function
             ParseRule nonTextRule = () => OneOf (ParseDivertArrow, ParseThreadArrow, EndOfLine, Glue);
+#pragma warning restore IDE0039 // Use local function
 
             CharacterSet endChars = null;
             if (parsingStringExpression) {

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Content.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Content.cs
@@ -14,7 +14,9 @@ namespace Ink
                 var lastObjIdx = mixedTextAndLogicResults.Count - 1;
                 var lastObj = mixedTextAndLogicResults[lastObjIdx];
                 if (lastObj is Text) {
+#pragma warning disable IDE0020 // Use pattern matching
                     var text = (Text)lastObj;
+#pragma warning restore IDE0020 // Use pattern matching
                     text.text = text.text.TrimEnd (' ', '\t');
 
                     if (terminateWithSpace)

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Divert.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Divert.cs
@@ -15,7 +15,9 @@ namespace Ink
             // Try single thread first
             var threadDivert = Parse(StartThread);
             if (threadDivert) {
+#pragma warning disable IDE0028 // Simplify collection initialization
                 diverts = new List<Object> ();
+#pragma warning restore IDE0028 // Simplify collection initialization
                 diverts.Add (threadDivert);
                 return diverts;
             }

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Divert.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Divert.cs
@@ -87,7 +87,9 @@ namespace Ink
 
             // Single -> (used for default choices)
             if (diverts.Count == 0 && arrowsAndDiverts.Count == 1) {
+#pragma warning disable IDE0017 // Simplify object initialization
                 var gatherDivert = new Divert ((Parsed.Object)null);
+#pragma warning restore IDE0017 // Simplify object initialization
                 gatherDivert.isEmpty = true;
                 diverts.Add (gatherDivert);
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Expressions.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Expressions.cs
@@ -62,7 +62,9 @@ namespace Ink
                 var result = new IncDecExpression (varIdentifier, assignedExpression, isIncrement);
                 return result;
             } else {
+#pragma warning disable IDE0017 // Simplify object initialization
                 var result = new VariableAssignment (varIdentifier, assignedExpression);
+#pragma warning restore IDE0017 // Simplify object initialization
                 result.isNewTemporaryDeclaration = isNewDeclaration;
                 return result;
             }

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Expressions.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Expressions.cs
@@ -208,7 +208,9 @@ namespace Ink
             if (postfixOp != null) {
                 bool isInc = postfixOp == "++";
 
+#pragma warning disable IDE0038 // Use pattern matching
                 if (!(expr is VariableReference)) {
+#pragma warning restore IDE0038 // Use pattern matching
                     Error ("can only increment and decrement variables, but saw '" + expr + "'");
 
                     // Drop down and succeed without the increment after reporting error

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Expressions.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Expressions.cs
@@ -295,7 +295,9 @@ namespace Ink
             parsingStringExpression = false;
 
             if (textAndLogic == null) {
+#pragma warning disable IDE0028 // Simplify collection initialization
                 textAndLogic = new List<Ink.Parsed.Object> ();
+#pragma warning restore IDE0028 // Simplify collection initialization
                 textAndLogic.Add (new Parsed.Text (""));
             }
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Include.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Include.cs
@@ -69,8 +69,12 @@ namespace Ink
             _rootParser._openFilenames.Remove (fullFilename);
         }
                    
+#pragma warning disable IDE0044 // Add readonly modifier
         InkParser _rootParser;
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         HashSet<string> _openFilenames;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Include.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Include.cs
@@ -41,7 +41,9 @@ namespace Ink
 
 
             if (includedString != null ) {
+#pragma warning disable IDE0090 // Use 'new(...)'
                 InkParser parser = new InkParser(includedString, filename, _externalErrorHandler, _rootParser);
+#pragma warning restore IDE0090 // Use 'new(...)'
                 includedStory = parser.Parse();
             }
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Knot.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Knot.cs
@@ -26,7 +26,9 @@ namespace Ink
 
 			Expect(EndOfLine, "end of line after knot name definition", recoveryRule: SkipToNextLine);
 
+#pragma warning disable IDE0039 // Use local function
 			ParseRule innerKnotStatements = () => StatementsAtLevel (StatementLevel.Knot);
+#pragma warning restore IDE0039 // Use local function
 
             var content = Expect (innerKnotStatements, "at least one line within the knot", recoveryRule: KnotStitchNoContentRecoveryRule) as List<Parsed.Object>;
 
@@ -90,7 +92,9 @@ namespace Ink
 
 			Expect(EndOfLine, "end of line after stitch name", recoveryRule: SkipToNextLine);
 
+#pragma warning disable IDE0039 // Use local function
 			ParseRule innerStitchStatements = () => StatementsAtLevel (StatementLevel.Stitch);
+#pragma warning restore IDE0039 // Use local function
 
             var content = Expect(innerStitchStatements, "at least one line within the stitch", recoveryRule: KnotStitchNoContentRecoveryRule) as List<Parsed.Object>;
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Knot.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Knot.cs
@@ -140,7 +140,9 @@ namespace Ink
             // Jump ahead to the next knot or the end of the file
             ParseUntil (KnotDeclaration, new CharacterSet ("="), null);
 
+#pragma warning disable IDE0028 // Simplify collection initialization
             var recoveredFlowContent = new List<Parsed.Object>();
+#pragma warning restore IDE0028 // Simplify collection initialization
 			recoveredFlowContent.Add( new Parsed.Text("<ERROR IN FLOW>" ) );
 			return recoveredFlowContent;
 		}

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Knot.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Knot.cs
@@ -225,7 +225,9 @@ namespace Ink
 
             Whitespace ();
 
+#pragma warning disable IDE0019 // Use pattern matching
             var parameterNames = Expect (BracketedKnotDeclArguments, "declaration of arguments for EXTERNAL, even if empty, i.e. 'EXTERNAL "+funcIdentifier+"()'") as List<FlowBase.Argument>;
+#pragma warning restore IDE0019 // Use pattern matching
             if (parameterNames == null)
                 parameterNames = new List<FlowBase.Argument> ();
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Logic.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Logic.cs
@@ -113,7 +113,9 @@ namespace Ink
                         Error ("Constant strings cannot contain any logic.");
                 }
 
+#pragma warning disable IDE0017 // Simplify object initialization
                 var result = new VariableAssignment (varName, expr);
+#pragma warning restore IDE0017 // Simplify object initialization
                 result.isGlobalDeclaration = true;
                 return result;
             }

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Logic.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Logic.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Linq;
 using Ink.Parsed;
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Logic.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Logic.cs
@@ -27,7 +27,9 @@ namespace Ink
             // ~ f()         -- expr
             // We don't treat variable decl/assign as an expression since we don't want an assignment
             // to have a return value, or to be used in compound expressions.
+#pragma warning disable IDE0039 // Use local function
             ParseRule afterTilda = () => OneOf (ReturnStatement, TempDeclarationOrAssignment, Expression);
+#pragma warning restore IDE0039 // Use local function
 
             var result = Expect(afterTilda, "expression after '~'", recoveryRule: SkipToNextLine) as Parsed.Object;
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Sequences.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Sequences.cs
@@ -79,7 +79,9 @@ namespace Ink
             return sequenceType;
         }
 
+#pragma warning disable IDE0090 // Use 'new(...)'
         CharacterSet _sequenceTypeSymbols = new CharacterSet("!&~$");
+#pragma warning restore IDE0090 // Use 'new(...)'
 
         protected object SequenceTypeWordAnnotation()
         {

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Sequences.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Sequences.cs
@@ -173,7 +173,9 @@ namespace Ink
                 // Real content
                 else {
 
+#pragma warning disable IDE0019 // Use pattern matching
                     var content = contentOrPipe as List<Parsed.Object>;
+#pragma warning restore IDE0019 // Use pattern matching
                     if (content == null) {
                         Error ("Expected content, but got " + contentOrPipe + " (this is an ink compiler bug!)");
                     } else {

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Statements.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Statements.cs
@@ -69,8 +69,12 @@ namespace Ink
             _statementBreakRulesAtLevel = new ParseRule[levels.Count][];
 
             foreach (var level in levels) {
+#pragma warning disable IDE0090 // Use 'new(...)'
                 List<ParseRule> rulesAtLevel = new List<ParseRule> ();
+#pragma warning restore IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0090 // Use 'new(...)'
                 List<ParseRule> breakingRules = new List<ParseRule> ();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
                 // Diverts can go anywhere
                 rulesAtLevel.Add(Line(MultiDivert));

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Tags.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Tags.cs
@@ -44,7 +44,9 @@ namespace Ink
             return tags.Cast<Parsed.Tag>().ToList();
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         CharacterSet _endOfTagCharSet = new CharacterSet ("#\n\r\\");
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Tags.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Tags.cs
@@ -45,7 +45,9 @@ namespace Ink
         }
 
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         CharacterSet _endOfTagCharSet = new CharacterSet ("#\n\r\\");
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Whitespace.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Whitespace.cs
@@ -107,7 +107,9 @@ namespace Ink
         }
 
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		private CharacterSet _inlineWhitespaceChars = new CharacterSet(" \t");
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 	}
 }

--- a/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Whitespace.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/InkParser/InkParser_Whitespace.cs
@@ -106,7 +106,9 @@ namespace Ink
             };
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
 		private CharacterSet _inlineWhitespaceChars = new CharacterSet(" \t");
+#pragma warning restore IDE0044 // Add readonly modifier
 	}
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Choice.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Choice.cs
@@ -123,7 +123,9 @@ namespace Ink.Parsed
             //  ]
             //
 
+#pragma warning disable IDE0017 // Simplify object initialization
             _runtimeChoice = new Runtime.ChoicePoint (onceOnly);
+#pragma warning restore IDE0017 // Simplify object initialization
             _runtimeChoice.isInvisibleDefault = this.isInvisibleDefault;
 
             if (startContent || choiceOnlyContent || condition) {
@@ -156,7 +158,9 @@ namespace Ink.Parsed
                 _startContentRuntimeContainer.name = "s";
 
                 // Effectively, the "return" statement - return to the point specified by $r
+#pragma warning disable IDE0017 // Simplify object initialization
                 var varDivert = new Runtime.Divert ();
+#pragma warning restore IDE0017 // Simplify object initialization
                 varDivert.variableDivertName = "$r";
                 _startContentRuntimeContainer.AddContent (varDivert);
 
@@ -164,7 +168,9 @@ namespace Ink.Parsed
                 _outerContainer.AddToNamedContentOnly (_startContentRuntimeContainer);
 
                 // This is the label to return to
+#pragma warning disable IDE0017 // Simplify object initialization
                 _r1Label = new Runtime.Container ();
+#pragma warning restore IDE0017 // Simplify object initialization
                 _r1Label.name = "$r1";
                 _outerContainer.AddContent (_r1Label);
 
@@ -218,7 +224,9 @@ namespace Ink.Parsed
                 _innerContentContainer.AddContent (_divertToStartContentInner);
 
                 // Define label to return to
+#pragma warning disable IDE0017 // Simplify object initialization
                 _r2Label = new Runtime.Container ();
+#pragma warning restore IDE0017 // Simplify object initialization
                 _r2Label.name = "$r2";
                 _innerContentContainer.AddContent (_r2Label);
             }

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Choice.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Choice.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿#pragma warning disable IDE1006
+
+using System.Text;
 
 namespace Ink.Parsed
 {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Conditional.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Conditional.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Linq;
 using Ink.Runtime;
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ConditionalSingleBranch.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ConditionalSingleBranch.cs
@@ -1,4 +1,5 @@
-﻿
+﻿#pragma warning disable IDE1006
+
 using System.Collections.Generic;
 
 namespace Ink.Parsed

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ConditionalSingleBranch.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ConditionalSingleBranch.cs
@@ -85,7 +85,9 @@ namespace Ink.Parsed
             if ( duplicatesStackValue )
                 container.AddContent (Runtime.ControlCommand.Duplicate ());
 
+#pragma warning disable IDE0017 // Simplify object initialization
             _conditionalDivert = new Runtime.Divert ();
+#pragma warning restore IDE0017 // Simplify object initialization
 
             // else clause is unconditional catch-all, otherwise the divert is conditional
             _conditionalDivert.isConditional = !isElse;

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ConditionalSingleBranch.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ConditionalSingleBranch.cs
@@ -153,7 +153,9 @@ namespace Ink.Parsed
         Runtime.Divert _conditionalDivert;
         Expression _ownExpression;
 
+#pragma warning disable IDE0044 // Add readonly modifier
         Weave _innerWeave;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ConstantDeclaration.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ConstantDeclaration.cs
@@ -1,4 +1,6 @@
-﻿//using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+//using System.Collections.Generic;
 
 namespace Ink.Parsed
 {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ContentList.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ContentList.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Text;
 
 namespace Ink.Parsed

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Divert.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Divert.cs
@@ -363,7 +363,9 @@ namespace Ink.Parsed
         {
             string externalName = target.firstComponent;
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             ExternalDeclaration external = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             var found = context.externals.TryGetValue(externalName, out external);
             System.Diagnostics.Debug.Assert (found, "external not found");

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Divert.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Divert.cs
@@ -362,7 +362,9 @@ namespace Ink.Parsed
         void CheckExternalArgumentValidity(Story context)
         {
             string externalName = target.firstComponent;
+#pragma warning disable IDE0018 // Inline variable declaration
             ExternalDeclaration external = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             var found = context.externals.TryGetValue(externalName, out external);
             System.Diagnostics.Debug.Assert (found, "external not found");
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Divert.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Divert.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Ink.Parsed

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/DivertTarget.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/DivertTarget.cs
@@ -68,7 +68,9 @@ namespace Ink.Parsed
                 else if (usageParent is MultipleConditionExpression) {
                     badUsage = true;
                     foundUsage = true;
+#pragma warning disable IDE0038 // Use pattern matching
                 } else if (usageParent is Choice && ((Choice)usageParent).condition == usageContext) {
+#pragma warning restore IDE0038 // Use pattern matching
                     badUsage = true;
                     foundUsage = true;
                 } else if (usageParent is Conditional || usageParent is ConditionalSingleBranch) {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Expression.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Expression.cs
@@ -138,19 +138,29 @@ namespace Ink.Parsed
             if( innerNumber ) {
 
                 if( op == "-" ) {
+#pragma warning disable IDE0038 // Use pattern matching
                     if( innerNumber.value is int ) {
+#pragma warning restore IDE0038 // Use pattern matching
                         return new Number( -((int)innerNumber.value) );
+#pragma warning disable IDE0038 // Use pattern matching
                     } else if( innerNumber.value is float ) {
+#pragma warning restore IDE0038 // Use pattern matching
                         return new Number( -((float)innerNumber.value) );
                     }
                 }
 
                 else if( op == "!" || op == "not" ) {
+#pragma warning disable IDE0038 // Use pattern matching
                     if( innerNumber.value is int ) {
+#pragma warning restore IDE0038 // Use pattern matching
                         return new Number( (int)innerNumber.value == 0 );
+#pragma warning disable IDE0038 // Use pattern matching
                     } else if( innerNumber.value is float ) {
+#pragma warning restore IDE0038 // Use pattern matching
                         return new Number( (float)innerNumber.value == 0.0f );
+#pragma warning disable IDE0038 // Use pattern matching
                     } else if( innerNumber.value is bool ) {
+#pragma warning restore IDE0038 // Use pattern matching
                         return new Number( !(bool)innerNumber.value );
                     }
                 }

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Expression.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Expression.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Ink.Parsed

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ExternalDeclaration.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ExternalDeclaration.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 
 namespace Ink.Parsed

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FlowBase.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FlowBase.cs
@@ -298,7 +298,9 @@ namespace Ink.Parsed
 
             if ( level == FlowLevel.WeavePoint || level == null ) {
 
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 Parsed.Object weavePointResult = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
                 if (_rootWeave) {
                     weavePointResult = (Parsed.Object)_rootWeave.WeavePointNamed (name);
@@ -317,7 +319,9 @@ namespace Ink.Parsed
                 return null;
 
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             FlowBase subFlow = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
 
             if (_subFlowsByName.TryGetValue (name, out subFlow)) {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FlowBase.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FlowBase.cs
@@ -216,7 +216,9 @@ namespace Ink.Parsed
                 // Inner knots and stitches
                 if (obj is FlowBase) {
 
+#pragma warning disable IDE0020 // Use pattern matching
                     var childFlow = (FlowBase)obj;
+#pragma warning restore IDE0020 // Use pattern matching
 
                     var childFlowRuntime = childFlow.runtimeObject;
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FlowBase.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FlowBase.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Parsed
 {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FlowBase.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FlowBase.cs
@@ -188,7 +188,9 @@ namespace Ink.Parsed
                 }
             }
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var container = new Runtime.Container ();
+#pragma warning restore IDE0017 // Simplify object initialization
             container.name = identifier?.name;
 
             if( this.story.countAllVisits ) {
@@ -229,7 +231,9 @@ namespace Ink.Parsed
 
                     // Check for duplicate knots/stitches with same name
                     var namedChild = (Runtime.INamedContent)childFlowRuntime;
+#pragma warning disable IDE0018 // Inline variable declaration
                     Runtime.INamedContent existingChild = null;
+#pragma warning restore IDE0018 // Inline variable declaration
                     if (container.namedContent.TryGetValue(namedChild.name, out existingChild) ) {
                         var errorMsg = string.Format ("{0} already contains flow named '{1}' (at {2})",
                             this.GetType().Name,
@@ -312,7 +316,9 @@ namespace Ink.Parsed
             if (level != null && level < this.flowLevel)
                 return null;
 
+#pragma warning disable IDE0018 // Inline variable declaration
             FlowBase subFlow = null;
+#pragma warning restore IDE0018 // Inline variable declaration
 
             if (_subFlowsByName.TryGetValue (name, out subFlow)) {
                 if (level == null || level == subFlow.flowLevel)

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FunctionCall.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FunctionCall.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Parsed
 {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FunctionCall.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FunctionCall.cs
@@ -236,7 +236,9 @@ namespace Ink.Parsed
             return string.Format ("{0}({1})", name, strArgs);
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         Parsed.Divert _proxyDivert;
+#pragma warning restore IDE0044 // Add readonly modifier
         Parsed.DivertTarget _divertTargetToCount;
         Parsed.VariableReference _variableReferenceToCount;
     }

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FunctionCall.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/FunctionCall.cs
@@ -23,7 +23,9 @@ namespace Ink.Parsed
 
         public FunctionCall (Identifier functionName, List<Expression> arguments)
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             _proxyDivert = new Parsed.Divert(new Path(functionName), arguments);
+#pragma warning restore IDE0017 // Simplify object initialization
             _proxyDivert.isFunctionCall = true;
             AddContent (_proxyDivert);
         }

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Gather.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Gather.cs
@@ -20,7 +20,9 @@ namespace Ink.Parsed
 
         public override Runtime.Object GenerateRuntimeObject ()
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             var container = new Runtime.Container ();
+#pragma warning restore IDE0017 // Simplify object initialization
             container.name = name;
 
             if (this.story.countAllVisits) {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/INamedContent.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/INamedContent.cs
@@ -1,4 +1,5 @@
-﻿
+﻿#pragma warning disable IDE1006
+
 namespace Ink.Parsed
 {
     public interface INamedContent

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/IWeavePoint.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/IWeavePoint.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Parsed
 {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Identifier.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Identifier.cs
@@ -8,6 +8,8 @@ namespace Ink.Parsed {
             return name;
         }
 
+#pragma warning disable IDE0090 // Use 'new(...)'
         public static Identifier Done = new Identifier { name = "DONE", debugMetadata = null };
+#pragma warning restore IDE0090 // Use 'new(...)'
     }
 }

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/IncludedFile.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/IncludedFile.cs
@@ -1,4 +1,5 @@
-﻿
+﻿#pragma warning disable IDE1006
+
 namespace Ink.Parsed
 {
     public class IncludedFile : Parsed.Object

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/List.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/List.cs
@@ -20,7 +20,9 @@ namespace Ink.Parsed
                     var nameParts = itemIdentifier?.name.Split ('.');
 
                     string listName = null;
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                     string listItemName = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
                     if (nameParts.Length > 1) {
                         listName = nameParts [0];
                         listItemName = nameParts [1];

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ListDefinition.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ListDefinition.cs
@@ -36,7 +36,9 @@ namespace Ink.Parsed
                 }
             }
 
+#pragma warning disable IDE0018 // Inline variable declaration
             ListElementDefinition foundElement;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (_elementsByName.TryGetValue (itemName, out foundElement))
                 return foundElement;
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ListDefinition.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/ListDefinition.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Number.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Number.cs
@@ -16,18 +16,26 @@ namespace Ink.Parsed
 
         public override void GenerateIntoContainer (Runtime.Container container)
 		{
+#pragma warning disable IDE0038 // Use pattern matching
             if (value is int) {
+#pragma warning restore IDE0038 // Use pattern matching
                 container.AddContent (new Runtime.IntValue ((int)value));
+#pragma warning disable IDE0038 // Use pattern matching
             } else if (value is float) {
+#pragma warning restore IDE0038 // Use pattern matching
                 container.AddContent (new Runtime.FloatValue ((float)value));
+#pragma warning disable IDE0038 // Use pattern matching
             } else if(value is bool) {
+#pragma warning restore IDE0038 // Use pattern matching
                 container.AddContent (new Runtime.BoolValue ((bool)value));
             }
 		}
 
         public override string ToString ()
         {
+#pragma warning disable IDE0038 // Use pattern matching
             if (value is float) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return ((float)value).ToString(System.Globalization.CultureInfo.InvariantCulture);
             } else {
                 return value.ToString();

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Object.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Object.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Text;
 
 namespace Ink.Parsed

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Object.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Object.cs
@@ -288,7 +288,9 @@ namespace Ink.Parsed
         {
             var ancestor = this.parent;
             while (ancestor) {
+#pragma warning disable IDE0038 // Use pattern matching
                 if (ancestor is FlowBase) {
+#pragma warning restore IDE0038 // Use pattern matching
                     return (FlowBase)ancestor;
                 }
                 ancestor = ancestor.parent;

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Object.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Object.cs
@@ -342,7 +342,9 @@ namespace Ink.Parsed
         // if( myObj != null ) ...
         public static implicit operator bool (Object obj)
         {
+#pragma warning disable IDE0041 // Use 'is null' check
             var isNull = object.ReferenceEquals (obj, null);
+#pragma warning restore IDE0041 // Use 'is null' check
             return !isNull;
         }
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Object.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Object.cs
@@ -120,7 +120,9 @@ namespace Ink.Parsed
                     break;
 
                 if (!hasWeavePoint) {
+#pragma warning disable IDE0019 // Use pattern matching
                     var weavePointAncestor = ancestor as IWeavePoint;
+#pragma warning restore IDE0019 // Use pattern matching
                     if (weavePointAncestor != null && weavePointAncestor.identifier != null) {
                         pathComponents.Add (weavePointAncestor.identifier);
                         hasWeavePoint = true;
@@ -231,7 +233,9 @@ namespace Ink.Parsed
         public delegate bool FindQueryFunc<T>(T obj);
         public T Find<T>(FindQueryFunc<T> queryFunc = null) where T : class
         {
+#pragma warning disable IDE0019 // Use pattern matching
             var tObj = this as T;
+#pragma warning restore IDE0019 // Use pattern matching
             if (tObj != null && (queryFunc == null || queryFunc (tObj) == true)) {
                 return tObj;
             }
@@ -260,7 +264,9 @@ namespace Ink.Parsed
 
         void FindAll<T>(FindQueryFunc<T> queryFunc, List<T> foundSoFar) where T : class
         {
+#pragma warning disable IDE0019 // Use pattern matching
             var tObj = this as T;
+#pragma warning restore IDE0019 // Use pattern matching
             if (tObj != null && (queryFunc == null || queryFunc (tObj) == true)) {
                 foundSoFar.Add (tObj);
             }

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Path.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Path.cs
@@ -66,7 +66,9 @@ namespace Ink.Parsed
         public Path(Identifier ambiguousName)
         {
             _baseTargetLevel = null;
+#pragma warning disable IDE0028 // Simplify collection initialization
             components = new List<Identifier> ();
+#pragma warning restore IDE0028 // Simplify collection initialization
             components.Add (ambiguousName);
         }
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Path.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Path.cs
@@ -188,7 +188,9 @@ namespace Ink.Parsed
             return null;
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         FlowLevel? _baseTargetLevel;
+#pragma warning restore IDE0044 // Add readonly modifier
 	}
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Path.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Path.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Return.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Return.cs
@@ -1,4 +1,6 @@
-﻿namespace Ink.Parsed
+﻿#pragma warning disable IDE1006
+
+namespace Ink.Parsed
 {
     public class Return : Parsed.Object
     {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Sequence.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Sequence.cs
@@ -26,7 +26,9 @@ namespace Ink.Parsed
 
                 var contentObjs = elementContentList.content;
 
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 Parsed.Object seqElObject = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
                 // Don't attempt to create a weave for the sequence element 
                 // if the content list is empty. Weaves don't like it!

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Sequence.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Sequence.cs
@@ -60,7 +60,9 @@ namespace Ink.Parsed
         //
         public override Runtime.Object GenerateRuntimeObject ()
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             var container = new Runtime.Container ();
+#pragma warning restore IDE0017 // Simplify object initialization
             container.visitsShouldBeCounted = true;
             container.countingAtStartOnly = true;
 
@@ -109,7 +111,9 @@ namespace Ink.Parsed
                     container.AddContent(new Runtime.IntValue(lastIdx));
                     container.AddContent(Runtime.NativeFunctionCall.CallWithName("=="));
 
+#pragma warning disable IDE0017 // Simplify object initialization
                     var skipShuffleDivert = new Runtime.Divert();
+#pragma warning restore IDE0017 // Simplify object initialization
                     skipShuffleDivert.isConditional = true;
                     container.AddContent(skipShuffleDivert);
 
@@ -143,7 +147,9 @@ namespace Ink.Parsed
                 container.AddContent (Runtime.ControlCommand.EvalEnd ());
 
                 // Divert branch for this sequence element
+#pragma warning disable IDE0017 // Simplify object initialization
                 var sequenceDivert = new Runtime.Divert ();
+#pragma warning restore IDE0017 // Simplify object initialization
                 sequenceDivert.isConditional = true;
                 container.AddContent (sequenceDivert);
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
@@ -62,7 +62,9 @@ namespace Ink.Parsed
                 var obj = topLevelContent [i];
                 if (obj is IncludedFile) {
 
+#pragma warning disable IDE0020 // Use pattern matching
                     var file = (IncludedFile)obj;
+#pragma warning restore IDE0020 // Use pattern matching
 
                     // Remove the IncludedFile itself
                     topLevelContent.RemoveAt (i);

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
@@ -79,7 +79,9 @@ namespace Ink.Parsed
                         if (subStory.content != null) {
 
                             foreach (var subStoryObj in subStory.content) {
+#pragma warning disable IDE0038 // Use pattern matching
                                 if (subStoryObj is FlowBase) {
+#pragma warning restore IDE0038 // Use pattern matching
                                     flowsFromOtherFiles.Add ((FlowBase)subStoryObj);
                                 } else {
                                     nonFlowContent.Add (subStoryObj);

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
@@ -502,7 +502,9 @@ namespace Ink.Parsed
         bool _hadError;
         bool _hadWarning;
 
+#pragma warning disable IDE0044 // Add readonly modifier
         HashSet<Runtime.Container> _dontFlattenContainers = new HashSet<Runtime.Container>();
+#pragma warning restore IDE0044 // Add readonly modifier
 
         Dictionary<string, Parsed.ListDefinition> _listDefs;
 	}

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
@@ -402,7 +402,9 @@ namespace Ink.Parsed
 
         public static bool IsReservedKeyword (string name)
         {
+#pragma warning disable IDE0066 // Convert switch statement to expression
             switch (name) {
+#pragma warning restore IDE0066 // Convert switch statement to expression
             case "true":
             case "false":
             case "not":

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
@@ -130,7 +130,9 @@ namespace Ink.Parsed
 
                 // Check for duplicate definitions
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 Parsed.Expression existingDefinition = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
                 if (constants.TryGetValue (constDecl.constantName, out existingDefinition)) {
                     if (!existingDefinition.Equals (constDecl.expression)) {
@@ -241,7 +243,9 @@ namespace Ink.Parsed
 
         public ListElementDefinition ResolveListItem (string listName, string itemName, Parsed.Object source = null)
         {
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             ListDefinition listDef = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
             // Search a specific list if we know its name (i.e. the form listName.itemName)
             if (listName != null) {
@@ -473,7 +477,9 @@ namespace Ink.Parsed
 
             // Global variable collision
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             VariableAssignment varDecl = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             if (variableDeclarations.TryGetValue(identifier?.name, out varDecl) ) {
                 if (varDecl != obj && varDecl.isGlobalDeclaration && varDecl.listDefinition == null) {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Runtime.CompilerServices;

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
@@ -503,7 +503,9 @@ namespace Ink.Parsed
         bool _hadWarning;
 
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         HashSet<Runtime.Container> _dontFlattenContainers = new HashSet<Runtime.Container>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 
         Dictionary<string, Parsed.ListDefinition> _listDefs;

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Story.cs
@@ -129,7 +129,9 @@ namespace Ink.Parsed
             foreach (var constDecl in FindAll<ConstantDeclaration> ()) {
 
                 // Check for duplicate definitions
+#pragma warning disable IDE0018 // Inline variable declaration
                 Parsed.Expression existingDefinition = null;
+#pragma warning restore IDE0018 // Inline variable declaration
                 if (constants.TryGetValue (constDecl.constantName, out existingDefinition)) {
                     if (!existingDefinition.Equals (constDecl.expression)) {
                         var errorMsg = string.Format ("CONST '{0}' has been redefined with a different value. Multiple definitions of the same CONST are valid so long as they contain the same value. Initial definition was on {1}.", constDecl.constantName, existingDefinition.debugMetadata);
@@ -178,7 +180,9 @@ namespace Ink.Parsed
                         varDecl.expression.GenerateIntoContainer (variableInitialisation);
                     }
 
+#pragma warning disable IDE0017 // Simplify object initialization
                     var runtimeVarAss = new Runtime.VariableAssignment (varName, isNewDeclaration:true);
+#pragma warning restore IDE0017 // Simplify object initialization
                     runtimeVarAss.isGlobal = true;
                     variableInitialisation.AddContent (runtimeVarAss);
                 }
@@ -227,7 +231,9 @@ namespace Ink.Parsed
 
         public ListDefinition ResolveList (string listName)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
             ListDefinition list;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (!_listDefs.TryGetValue (listName, out list))
                 return null;
             return list;
@@ -466,7 +472,9 @@ namespace Ink.Parsed
             if (symbolType <= SymbolType.Var) return;
 
             // Global variable collision
+#pragma warning disable IDE0018 // Inline variable declaration
             VariableAssignment varDecl = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (variableDeclarations.TryGetValue(identifier?.name, out varDecl) ) {
                 if (varDecl != obj && varDecl.isGlobalDeclaration && varDecl.listDefinition == null) {
                     NameConflictError (obj, identifier?.name, varDecl, typeNameToPrint);

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/StringExpression.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/StringExpression.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Text.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Text.cs
@@ -1,4 +1,5 @@
-﻿
+﻿#pragma warning disable IDE1006
+
 namespace Ink.Parsed
 {
 	public class Text : Parsed.Object

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/TunnelOnwards.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/TunnelOnwards.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Parsed
 {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/VariableAssignment.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/VariableAssignment.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Parsed
 {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/VariableReference.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/VariableReference.cs
@@ -52,7 +52,9 @@ namespace Ink.Parsed
         public override void GenerateIntoContainer (Runtime.Container container)
         {
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             Expression constantValue = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
 
             // If it's a constant reference, just generate the literal expression value
@@ -70,7 +72,9 @@ namespace Ink.Parsed
             // List item reference?
             // Path might be to a list (listName.listItemName or just listItemName)
             if (path.Count == 1 || path.Count == 2) {
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 string listItemName = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
                 string listName = null;
 
                 if (path.Count == 1) listItemName = path [0];

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/VariableReference.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/VariableReference.cs
@@ -51,7 +51,9 @@ namespace Ink.Parsed
 
         public override void GenerateIntoContainer (Runtime.Container container)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
             Expression constantValue = null;
+#pragma warning restore IDE0018 // Inline variable declaration
 
             // If it's a constant reference, just generate the literal expression value
             // It's okay to access the constants at code generation time, since the

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/VariableReference.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/VariableReference.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Ink.Parsed

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
@@ -261,7 +261,9 @@ namespace Ink.Parsed
                     }
                 }
 
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 Runtime.Divert divert = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
                 if (looseEnd is Parsed.Divert) {
                     divert = (Runtime.Divert) looseEnd.runtimeObject;
@@ -491,7 +493,9 @@ namespace Ink.Parsed
                 return null;
 
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             IWeavePoint weavePointResult = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             if (_namedWeavePoints.TryGetValue (name, out weavePointResult))
                 return weavePointResult;

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
@@ -89,7 +89,9 @@ namespace Ink.Parsed
             foreach (var weavePoint in namedWeavePoints) {
 
                 // Check for weave point naming collisions
+#pragma warning disable IDE0018 // Inline variable declaration
                 IWeavePoint existingWeavePoint;
+#pragma warning restore IDE0018 // Inline variable declaration
                 if (_namedWeavePoints.TryGetValue (weavePoint.name, out existingWeavePoint)) {
                     var typeName = existingWeavePoint is Gather ? "gather" : "choice";
                     var existingObj = (Parsed.Object)existingWeavePoint;
@@ -488,7 +490,9 @@ namespace Ink.Parsed
             if (_namedWeavePoints == null)
                 return null;
 
+#pragma warning disable IDE0018 // Inline variable declaration
             IWeavePoint weavePointResult = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (_namedWeavePoints.TryGetValue (name, out weavePointResult))
                 return weavePointResult;
 

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Parsed
 {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
@@ -124,7 +124,9 @@ namespace Ink.Parsed
                         // Step through content until indent jumps out again
                         int innerWeaveStartIdx = contentIdx;
                         while (contentIdx < content.Count) {
+#pragma warning disable IDE0019 // Use pattern matching
                             var innerWeaveObj = content [contentIdx] as IWeavePoint;
+#pragma warning restore IDE0019 // Use pattern matching
                             if (innerWeaveObj != null) {
                                 var innerIndentIdx = innerWeaveObj.indentationDepth - 1;
                                 if (innerIndentIdx <= baseIndentIndex) {

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
@@ -115,7 +115,9 @@ namespace Ink.Parsed
 
                 // Choice or Gather
                 if (obj is IWeavePoint) {
+#pragma warning disable IDE0020 // Use pattern matching
                     var weavePoint = (IWeavePoint)obj;
+#pragma warning restore IDE0020 // Use pattern matching
                     var weaveIndentIdx = weavePoint.indentationDepth - 1;
 
                     // Inner level indentation - recurse
@@ -197,7 +199,9 @@ namespace Ink.Parsed
 
                     // Nested weave
                     if (obj is Weave) {
+#pragma warning disable IDE0020 // Use pattern matching
                         var weave = (Weave)obj;
+#pragma warning restore IDE0020 // Use pattern matching
                         AddRuntimeForNestedWeave (weave);
                         gatherPointsToResolve.AddRange (weave.gatherPointsToResolve);
                     }
@@ -257,7 +261,9 @@ namespace Ink.Parsed
                 // since they'll be handled by the auto-enter code below
                 // that only jumps into the gather if (current runtime choices == 0)
                 if (looseEnd is Gather) {
+#pragma warning disable IDE0020 // Use pattern matching
                     var prevGather = (Gather)looseEnd;
+#pragma warning restore IDE0020 // Use pattern matching
                     if (prevGather.indentationDepth == gather.indentationDepth) {
                         continue;
                     }

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Weave.cs
@@ -157,7 +157,9 @@ namespace Ink.Parsed
         public int DetermineBaseIndentationFromContent(List<Parsed.Object> contentList)
         {
             foreach (var obj in contentList) {
+#pragma warning disable IDE0038 // Use pattern matching
                 if (obj is IWeavePoint) {
+#pragma warning restore IDE0038 // Use pattern matching
                     return ((IWeavePoint)obj).indentationDepth - 1;
                 }
             }
@@ -180,7 +182,9 @@ namespace Ink.Parsed
             foreach(var obj in content) {
 
                 // Choice or Gather
+#pragma warning disable IDE0038 // Use pattern matching
                 if (obj is IWeavePoint) {
+#pragma warning restore IDE0038 // Use pattern matching
                     AddRuntimeForWeavePoint ((IWeavePoint)obj);
                 } 
 
@@ -279,12 +283,16 @@ namespace Ink.Parsed
         void AddRuntimeForWeavePoint(IWeavePoint weavePoint)
         {
             // Current level Gather
+#pragma warning disable IDE0038 // Use pattern matching
             if (weavePoint is Gather) {
+#pragma warning restore IDE0038 // Use pattern matching
                 AddRuntimeForGather ((Gather)weavePoint);
             } 
 
             // Current level choice
+#pragma warning disable IDE0038 // Use pattern matching
             else if (weavePoint is Choice) {
+#pragma warning restore IDE0038 // Use pattern matching
 
                 // Gathers that contain choices are no longer loose ends
                 // (same as when weave points get nested content)

--- a/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Wrap.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/ParsedHierarchy/Wrap.cs
@@ -13,7 +13,9 @@ namespace Ink.Parsed
             return _objToWrap;
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         T _objToWrap;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 
     // Shorthand for writing Parsed.Wrap<Runtime.Glue> and Parsed.Wrap<Runtime.Tag>

--- a/Packages/Ink/InkLibs/InkCompiler/Plugins/PluginManager.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/Plugins/PluginManager.cs
@@ -34,7 +34,9 @@ namespace Ink
             }
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         List<IPlugin> _plugins;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
@@ -642,7 +642,9 @@ namespace Ink
                 return null;
             }
 
+#pragma warning disable IDE0018 // Inline variable declaration
 			int parsedInt;
+#pragma warning restore IDE0018 // Inline variable declaration
 			if (int.TryParse (parsedString, out parsedInt)) {
 				return negative ? -parsedInt : parsedInt;
 			}

--- a/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
@@ -270,7 +270,9 @@ namespace Ink
         {
             int ruleId = BeginRule ();
 
+#pragma warning disable IDE0019 // Use pattern matching
             var result = rule () as T;
+#pragma warning restore IDE0019 // Use pattern matching
             if (result == null) {
                 FailRule (ruleId);
                 return null;
@@ -358,7 +360,9 @@ namespace Ink
 			}
 
 			if (flatten) {
+#pragma warning disable IDE0019 // Use pattern matching
 				var resultCollection = result as System.Collections.ICollection;
+#pragma warning restore IDE0019 // Use pattern matching
 				if (resultCollection != null) {
 					foreach (object obj in resultCollection) {
 						Debug.Assert (obj is T);

--- a/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Diagnostics;

--- a/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
@@ -32,9 +32,13 @@ namespace Ink
 		}
 
 		public class ParseSuccessStruct {};
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public static ParseSuccessStruct ParseSuccess = new ParseSuccessStruct();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 		public static CharacterSet numbersCharacterSet = new CharacterSet("0123456789");
+#pragma warning restore IDE0090 // Use 'new(...)'
 
         protected ErrorHandler errorHandler { get; set; }
 
@@ -555,7 +559,9 @@ namespace Ink
 			int ruleId = BeginRule ();
 
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			CharacterSet pauseAndEnd = new CharacterSet ();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			if (pauseCharacters != null) {
 				pauseAndEnd.UnionWith (pauseCharacters);
 			}
@@ -563,7 +569,9 @@ namespace Ink
 				pauseAndEnd.UnionWith (endCharacters);
 			}
 
+#pragma warning disable IDE0090 // Use 'new(...)'
 			StringBuilder parsedString = new StringBuilder ();
+#pragma warning restore IDE0090 // Use 'new(...)'
 			object ruleResultAtPause = null;
 
 			// Keep attempting to parse strings up to the pause (and end) points.

--- a/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParser.cs
@@ -681,7 +681,9 @@ namespace Ink
             }
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
 		private char[] _chars;
+#pragma warning restore IDE0044 // Add readonly modifier
 	}
 }
 

--- a/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParserState.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParserState.cs
@@ -1,3 +1,4 @@
+#pragma warning disable IDE1006
 
 namespace Ink
 {

--- a/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParserState.cs
+++ b/Packages/Ink/InkLibs/InkCompiler/StringParser/StringParserState.cs
@@ -164,7 +164,9 @@ namespace Ink
 			}
 		}
 
+#pragma warning disable IDE0044 // Add readonly modifier
         private Element[] _stack;
+#pragma warning restore IDE0044 // Add readonly modifier
         private int _numElements;
 	}
 }

--- a/Packages/Ink/InkLibs/InkRuntime/CallStack.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/CallStack.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 

--- a/Packages/Ink/InkLibs/InkRuntime/CallStack.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/CallStack.cs
@@ -360,7 +360,9 @@ namespace Ink.Runtime
                 contextIndex = currentElementIndex+1;
             
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             Runtime.Object varValue = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
 
             var contextElement = callStack [contextIndex-1];

--- a/Packages/Ink/InkLibs/InkRuntime/CallStack.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/CallStack.cs
@@ -224,7 +224,9 @@ namespace Ink.Runtime
 
         public void Reset() 
         {
+#pragma warning disable IDE0028 // Simplify collection initialization
             _threads = new List<Thread>();
+#pragma warning restore IDE0028 // Simplify collection initialization
             _threads.Add(new Thread());
 
             _threads[0].callstack.Add(new Element(PushPopType.Tunnel, _startOfRoot));

--- a/Packages/Ink/InkLibs/InkRuntime/CallStack.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/CallStack.cs
@@ -34,7 +34,9 @@ namespace Ink.Runtime
 
             public Element Copy()
             {
+#pragma warning disable IDE0017 // Simplify object initialization
                 var copy = new Element (this.type, currentPointer, this.inExpressionEvaluation);
+#pragma warning restore IDE0017 // Simplify object initialization
                 copy.temporaryVariables = new Dictionary<string,Object>(this.temporaryVariables);
                 copy.evaluationStackHeightWhenPushed = evaluationStackHeightWhenPushed;
                 copy.functionStartInOuputStream = functionStartInOuputStream;
@@ -65,7 +67,9 @@ namespace Ink.Runtime
                     Pointer pointer = Pointer.Null;
 
 					string currentContainerPathStr = null;
+#pragma warning disable IDE0018 // Inline variable declaration
 					object currentContainerPathStrToken;
+#pragma warning restore IDE0018 // Inline variable declaration
 					if (jElementObj.TryGetValue ("cPath", out currentContainerPathStrToken)) {
 						currentContainerPathStr = currentContainerPathStrToken.ToString ();
 
@@ -83,7 +87,9 @@ namespace Ink.Runtime
 
 					var el = new Element (pushPopType, pointer, inExpressionEvaluation);
 
+#pragma warning disable IDE0018 // Inline variable declaration
                     object temps;
+#pragma warning restore IDE0018 // Inline variable declaration
                     if ( jElementObj.TryGetValue("temp", out temps) ) {
                         el.temporaryVariables = Json.JObjectToDictionaryRuntimeObjs((Dictionary<string, object>)temps);
                     } else {
@@ -93,7 +99,9 @@ namespace Ink.Runtime
 					callstack.Add (el);
 				}
 
+#pragma warning disable IDE0018 // Inline variable declaration
 				object prevContentObjPath;
+#pragma warning restore IDE0018 // Inline variable declaration
 				if( jThreadObj.TryGetValue("previousContentObject", out prevContentObjPath) ) {
 					var prevPath = new Path((string)prevContentObjPath);
                     previousPointer = storyContext.PointerAtPath(prevPath);
@@ -101,7 +109,9 @@ namespace Ink.Runtime
 			}
 
             public Thread Copy() {
+#pragma warning disable IDE0017 // Simplify object initialization
                 var copy = new Thread ();
+#pragma warning restore IDE0017 // Simplify object initialization
                 copy.threadIndex = threadIndex;
                 foreach(var e in callstack) {
                     copy.callstack.Add(e.Copy());
@@ -308,11 +318,13 @@ namespace Ink.Runtime
         public void Push(PushPopType type, int externalEvaluationStackHeight = 0, int outputStreamLengthWithPushed = 0)
         {
             // When pushing to callstack, maintain the current content path, but jump out of expressions by default
+#pragma warning disable IDE0017 // Simplify object initialization
             var element = new Element (
                 type, 
                 currentElement.currentPointer,
                 inExpressionEvaluation: false
             );
+#pragma warning restore IDE0017 // Simplify object initialization
 
             element.evaluationStackHeightWhenPushed = externalEvaluationStackHeight;
             element.functionStartInOuputStream = outputStreamLengthWithPushed;
@@ -347,7 +359,9 @@ namespace Ink.Runtime
             if (contextIndex == -1)
                 contextIndex = currentElementIndex+1;
             
+#pragma warning disable IDE0018 // Inline variable declaration
             Runtime.Object varValue = null;
+#pragma warning restore IDE0018 // Inline variable declaration
 
             var contextElement = callStack [contextIndex-1];
 
@@ -369,7 +383,9 @@ namespace Ink.Runtime
                 throw new System.Exception ("Could not find temporary variable to set: " + name);
             }
 
+#pragma warning disable IDE0018 // Inline variable declaration
             Runtime.Object oldValue;
+#pragma warning restore IDE0018 // Inline variable declaration
             if( contextElement.temporaryVariables.TryGetValue(name, out oldValue) )
                 ListValue.RetainListOriginsForAssignment (oldValue, value);
 

--- a/Packages/Ink/InkLibs/InkRuntime/Choice.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Choice.cs
@@ -1,4 +1,5 @@
-﻿
+﻿#pragma warning disable IDE1006
+
 namespace Ink.Runtime
 {
     /// <summary>

--- a/Packages/Ink/InkLibs/InkRuntime/ChoicePoint.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ChoicePoint.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿#pragma warning disable IDE1006
+
+using System.ComponentModel;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/Container.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Container.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE1006
+
 using System;
 using System.Diagnostics;
 using System.Collections.Generic;

--- a/Packages/Ink/InkLibs/InkRuntime/Container.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Container.cs
@@ -21,7 +21,9 @@ namespace Ink.Runtime
                 AddContent (value);
             }
         }
+#pragma warning disable IDE0044 // Add readonly modifier
         List<Runtime.Object> _content;
+#pragma warning restore IDE0044 // Add readonly modifier
 
 		public Dictionary<string, INamedContent> namedContent { get; set; }
 

--- a/Packages/Ink/InkLibs/InkRuntime/Container.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Container.cs
@@ -35,7 +35,9 @@ namespace Ink.Runtime
                 }
 
                 foreach (var c in content) {
+#pragma warning disable IDE0019 // Use pattern matching
                     var named = c as INamedContent;
+#pragma warning restore IDE0019 // Use pattern matching
                     if (named != null && named.hasValidName) {
                         namedOnlyContentDict.Remove (named.name);
                     }
@@ -58,7 +60,9 @@ namespace Ink.Runtime
                     return;
                 
                 foreach (var kvPair in value) {
+#pragma warning disable IDE0019 // Use pattern matching
                     var named = kvPair.Value as INamedContent;
+#pragma warning restore IDE0019 // Use pattern matching
                     if( named != null )
                         AddToNamedContentOnly (named);
                 }
@@ -176,7 +180,9 @@ namespace Ink.Runtime
             
 		public void TryAddNamedContent(Runtime.Object contentObj)
 		{
+#pragma warning disable IDE0019 // Use pattern matching
 			var namedContentObj = contentObj as INamedContent;
+#pragma warning restore IDE0019 // Use pattern matching
 			if (namedContentObj != null && namedContentObj.hasValidName) {
 				AddToNamedContentOnly (namedContentObj);
 			}

--- a/Packages/Ink/InkLibs/InkRuntime/Container.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Container.cs
@@ -311,7 +311,9 @@ namespace Ink.Runtime
 
                 if (obj is Container) {
 
+#pragma warning disable IDE0020 // Use pattern matching
                     var container = (Container)obj;
+#pragma warning restore IDE0020 // Use pattern matching
 
                     container.BuildStringOfHierarchy (sb, indentation, pointedObj);
 

--- a/Packages/Ink/InkLibs/InkRuntime/Container.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Container.cs
@@ -221,7 +221,9 @@ namespace Ink.Runtime
             }
 
             else {
+#pragma warning disable IDE0018 // Inline variable declaration
                 INamedContent foundContent = null;
+#pragma warning restore IDE0018 // Inline variable declaration
                 if (namedContent.TryGetValue (component.name, out foundContent)) {
                     return (Runtime.Object)foundContent;
                 } else {
@@ -235,7 +237,9 @@ namespace Ink.Runtime
             if (partialPathLength == -1)
                 partialPathLength = path.length;
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var result = new SearchResult ();
+#pragma warning restore IDE0017 // Simplify object initialization
             result.approximate = false;
 
             Container currentContainer = this;

--- a/Packages/Ink/InkLibs/InkRuntime/Container.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Container.cs
@@ -281,7 +281,9 @@ namespace Ink.Runtime
          
         public void BuildStringOfHierarchy(StringBuilder sb, int indentation, Runtime.Object pointedObj)
         {
+#pragma warning disable IDE0039 // Use local function
             Action appendIndentation = () => { 
+#pragma warning restore IDE0039 // Use local function
                 const int spacesPerIndent = 4;
                 for(int i=0; i<spacesPerIndent*indentation;++i) { 
                     sb.Append(" "); 

--- a/Packages/Ink/InkLibs/InkRuntime/Container.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Container.cs
@@ -222,7 +222,9 @@ namespace Ink.Runtime
 
             else {
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 INamedContent foundContent = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
                 if (namedContent.TryGetValue (component.name, out foundContent)) {
                     return (Runtime.Object)foundContent;

--- a/Packages/Ink/InkLibs/InkRuntime/ControlCommand.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ControlCommand.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/DebugMetadata.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/DebugMetadata.cs
@@ -20,7 +20,9 @@ namespace Ink.Runtime
         // one single range.
         public DebugMetadata Merge(DebugMetadata dm)
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             var newDebugMetadata = new DebugMetadata();
+#pragma warning restore IDE0017 // Simplify object initialization
 
             // These are not supposed to be differ between 'this' and 'dm'.
             newDebugMetadata.fileName = fileName;

--- a/Packages/Ink/InkLibs/InkRuntime/Divert.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Divert.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿#pragma warning disable IDE1006
+
+using System.Text;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/Flow.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Flow.cs
@@ -23,7 +23,9 @@ namespace Ink.Runtime
 			this.currentChoices = Json.JArrayToRuntimeObjList<Choice>((List<object>)jObject ["currentChoices"]);
 
             // choiceThreads is optional
+#pragma warning disable IDE0018 // Inline variable declaration
             object jChoiceThreadsObj;
+#pragma warning restore IDE0018 // Inline variable declaration
             jObject.TryGetValue("choiceThreads", out jChoiceThreadsObj);
             LoadFlowChoiceThreads((Dictionary<string, object>)jChoiceThreadsObj, story);
         }

--- a/Packages/Ink/InkLibs/InkRuntime/INamedContent.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/INamedContent.cs
@@ -1,4 +1,5 @@
-﻿
+﻿#pragma warning disable IDE1006
+
 namespace Ink.Runtime
 {
 	public interface INamedContent

--- a/Packages/Ink/InkLibs/InkRuntime/InkList.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/InkList.cs
@@ -490,22 +490,30 @@ namespace Ink.Runtime
             int minValue = 0;
             int maxValue = int.MaxValue;
 
+#pragma warning disable IDE0038 // Use pattern matching
             if (minBound is int)
+#pragma warning restore IDE0038 // Use pattern matching
             {
                 minValue = (int)minBound;
             }
 
             else
             {
+#pragma warning disable IDE0038 // Use pattern matching
                 if( minBound is InkList && ((InkList)minBound).Count > 0 )
+#pragma warning restore IDE0038 // Use pattern matching
                     minValue = ((InkList)minBound).minItem.Value;
             }
 
+#pragma warning disable IDE0038 // Use pattern matching
             if (maxBound is int)
+#pragma warning restore IDE0038 // Use pattern matching
                 maxValue = (int)maxBound;
             else 
             {
+#pragma warning disable IDE0038 // Use pattern matching
                 if (minBound is InkList && ((InkList)minBound).Count > 0)
+#pragma warning restore IDE0038 // Use pattern matching
                     maxValue = ((InkList)maxBound).maxItem.Value;
             }
 

--- a/Packages/Ink/InkLibs/InkRuntime/InkList.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/InkList.cs
@@ -134,7 +134,9 @@ namespace Ink.Runtime
         {
             SetInitialOriginName (singleOriginListName);
 
+#pragma warning disable IDE0018 // Inline variable declaration
             ListDefinition def;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (originStory.listDefinitions.TryListGetDefinition (singleOriginListName, out def))
                 origins = new List<ListDefinition> { def };
             else
@@ -176,7 +178,9 @@ namespace Ink.Runtime
             
             foreach (var origin in origins) {
                 if (origin.name == item.originName) {
+#pragma warning disable IDE0018 // Inline variable declaration
                     int intVal;
+#pragma warning restore IDE0018 // Inline variable declaration
                     if (origin.TryGetValueForItem (item, out intVal)) {
                         this [item] = intVal;
                         return;

--- a/Packages/Ink/InkLibs/InkRuntime/InkList.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/InkList.cs
@@ -538,7 +538,9 @@ namespace Ink.Runtime
         /// </summary>
         public override bool Equals (object other)
         {
+#pragma warning disable IDE0019 // Use pattern matching
             var otherRawList = other as InkList;
+#pragma warning restore IDE0019 // Use pattern matching
             if (otherRawList == null) return false;
             if (otherRawList.Count != Count) return false;
 

--- a/Packages/Ink/InkLibs/InkRuntime/InkList.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/InkList.cs
@@ -287,7 +287,9 @@ namespace Ink.Runtime
         /// </summary>
         public KeyValuePair<InkListItem, int> maxItem {
             get {
+#pragma warning disable IDE0090 // Use 'new(...)'
                 KeyValuePair<InkListItem, int> max = new KeyValuePair<InkListItem, int>();
+#pragma warning restore IDE0090 // Use 'new(...)'
                 foreach (var kv in this) {
                     if (max.Key.isNull || kv.Value > max.Value)
                         max = kv;

--- a/Packages/Ink/InkLibs/InkRuntime/InkList.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/InkList.cs
@@ -78,7 +78,9 @@ namespace Ink.Runtime
         public override bool Equals (object obj)
         {
             if (obj is InkListItem) {
+#pragma warning disable IDE0020 // Use pattern matching
                 var otherItem = (InkListItem)obj;
+#pragma warning restore IDE0020 // Use pattern matching
                 return otherItem.itemName   == itemName 
                     && otherItem.originName == originName;
             }

--- a/Packages/Ink/InkLibs/InkRuntime/InkList.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/InkList.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 using System.Text;
 
 namespace Ink.Runtime

--- a/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
@@ -587,7 +587,9 @@ namespace Ink.Runtime
             //  - named content
             //  - a "#f" key with the countFlags
             // (if either exists at all, otherwise null)
+#pragma warning disable IDE0019 // Use pattern matching
             var terminatingObj = jArray [jArray.Count - 1] as Dictionary<string, object>;
+#pragma warning restore IDE0019 // Use pattern matching
             if (terminatingObj != null) {
 
                 var namedOnlyContent = new Dictionary<string, Runtime.Object> (terminatingObj.Count);

--- a/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
@@ -503,7 +503,9 @@ namespace Ink.Runtime
             }
 
             // Array is always a Runtime.Container
+#pragma warning disable IDE0038 // Use pattern matching
             if (token is List<object>) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return JArrayToContainer((List<object>)token);
             }
 

--- a/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
@@ -377,7 +377,9 @@ namespace Ink.Runtime
             if (token is Dictionary<string, object>) {
 
                 var obj = (Dictionary < string, object> )token;
+#pragma warning disable IDE0018 // Inline variable declaration
                 object propValue;
+#pragma warning restore IDE0018 // Inline variable declaration
 
                 // Divert target value to path
                 if (obj.TryGetValue ("^->", out propValue))
@@ -416,7 +418,9 @@ namespace Ink.Runtime
                     divPushType = PushPopType.Function;
                 }
                 if (isDivert) {
+#pragma warning disable IDE0017 // Simplify object initialization
                     var divert = new Divert ();
+#pragma warning restore IDE0017 // Simplify object initialization
                     divert.pushesToStack = pushesToStack;
                     divert.stackPushType = divPushType;
                     divert.isExternal = external;
@@ -440,7 +444,9 @@ namespace Ink.Runtime
                     
                 // Choice
                 if (obj.TryGetValue ("*", out propValue)) {
+#pragma warning disable IDE0017 // Simplify object initialization
                     var choice = new ChoicePoint ();
+#pragma warning restore IDE0017 // Simplify object initialization
                     choice.pathStringOnChoice = propValue.ToString();
 
                     if (obj.TryGetValue ("flg", out propValue))
@@ -453,7 +459,9 @@ namespace Ink.Runtime
                 if (obj.TryGetValue ("VAR?", out propValue)) {
                     return new VariableReference (propValue.ToString ());
                 } else if (obj.TryGetValue ("CNT?", out propValue)) {
+#pragma warning disable IDE0017 // Simplify object initialization
                     var readCountVarRef = new VariableReference ();
+#pragma warning restore IDE0017 // Simplify object initialization
                     readCountVarRef.pathStringForCount = propValue.ToString ();
                     return readCountVarRef;
                 }
@@ -471,7 +479,9 @@ namespace Ink.Runtime
                 if (isVarAss) {
                     var varName = propValue.ToString ();
                     var isNewDecl = !obj.TryGetValue("re", out propValue);
+#pragma warning disable IDE0017 // Simplify object initialization
                     var varAss = new VariableAssignment (varName, isNewDecl);
+#pragma warning restore IDE0017 // Simplify object initialization
                     varAss.isGlobal = isGlobalVar;
                     return varAss;
                 }
@@ -562,7 +572,9 @@ namespace Ink.Runtime
 
         static Container JArrayToContainer(List<object> jArray)
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             var container = new Container ();
+#pragma warning restore IDE0017 // Simplify object initialization
             container.content = JArrayToRuntimeObjList (jArray, skipLast:true);
 
             // Final object in the array is always a combination of
@@ -596,7 +608,9 @@ namespace Ink.Runtime
 
         static Choice JObjectToChoice(Dictionary<string, object> jObj)
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             var choice = new Choice();
+#pragma warning restore IDE0017 // Simplify object initialization
             choice.text = jObj ["text"].ToString();
             choice.index = (int)jObj ["index"];
             choice.sourcePath = jObj ["originalChoicePath"].ToString();

--- a/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
@@ -713,7 +713,9 @@ namespace Ink.Runtime
             }
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         static string[] _controlCommandNames;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }
 

--- a/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
@@ -427,12 +427,16 @@ namespace Ink.Runtime
 
                     string target = propValue.ToString ();
 
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                     if (obj.TryGetValue ("var", out propValue))
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
                         divert.variableDivertName = target;
                     else
                         divert.targetPathString = target;
 
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                     divert.isConditional = obj.TryGetValue("c", out propValue);
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
                     if (external) {
                         if (obj.TryGetValue ("exArgs", out propValue))
@@ -478,7 +482,9 @@ namespace Ink.Runtime
                 }
                 if (isVarAss) {
                     var varName = propValue.ToString ();
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                     var isNewDecl = !obj.TryGetValue("re", out propValue);
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning disable IDE0017 // Simplify object initialization
                     var varAss = new VariableAssignment (varName, isNewDecl);
 #pragma warning restore IDE0017 // Simplify object initialization

--- a/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
@@ -335,7 +335,9 @@ namespace Ink.Runtime
             }
             
             if (token is string) {
+#pragma warning disable IDE0020 // Use pattern matching
                 string str = (string)token;
+#pragma warning restore IDE0020 // Use pattern matching
 
                 // String value
                 char firstChar = str[0];
@@ -376,7 +378,9 @@ namespace Ink.Runtime
 
             if (token is Dictionary<string, object>) {
 
+#pragma warning disable IDE0020 // Use pattern matching
                 var obj = (Dictionary < string, object> )token;
+#pragma warning restore IDE0020 // Use pattern matching
 #pragma warning disable IDE0018 // Inline variable declaration
                 object propValue;
 #pragma warning restore IDE0018 // Inline variable declaration

--- a/Packages/Ink/InkLibs/InkRuntime/ListDefinition.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ListDefinition.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/ListDefinition.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ListDefinition.cs
@@ -24,7 +24,9 @@ namespace Ink.Runtime
 
         public int ValueForItem (InkListItem item)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
             int intVal;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (_itemNameToValues.TryGetValue (item.itemName, out intVal))
                 return intVal;
             else

--- a/Packages/Ink/InkLibs/InkRuntime/ListDefinition.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ListDefinition.cs
@@ -67,11 +67,15 @@ namespace Ink.Runtime
             _itemNameToValues = items;
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         string _name;
+#pragma warning restore IDE0044 // Add readonly modifier
 
         // The main representation should be simple item names rather than a RawListItem,
         // since we mainly want to access items based on their simple name, since that's
         // how they'll be most commonly requested from ink.
+#pragma warning disable IDE0044 // Add readonly modifier
         Dictionary<string, int> _itemNameToValues;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/Packages/Ink/InkLibs/InkRuntime/ListDefinitionsOrigin.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ListDefinitionsOrigin.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/ListDefinitionsOrigin.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ListDefinitionsOrigin.cs
@@ -45,7 +45,9 @@ namespace Ink.Runtime
         public ListValue FindSingleItemListWithName (string name)
         {
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
 			ListValue val = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
 			_allUnambiguousListValueCache.TryGetValue(name, out val);
 			return val;

--- a/Packages/Ink/InkLibs/InkRuntime/ListDefinitionsOrigin.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ListDefinitionsOrigin.cs
@@ -49,7 +49,11 @@ namespace Ink.Runtime
 			return val;
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         Dictionary<string, Runtime.ListDefinition> _lists;
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
 		Dictionary<string, ListValue> _allUnambiguousListValueCache;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/Packages/Ink/InkLibs/InkRuntime/ListDefinitionsOrigin.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/ListDefinitionsOrigin.cs
@@ -44,7 +44,9 @@ namespace Ink.Runtime
 
         public ListValue FindSingleItemListWithName (string name)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
 			ListValue val = null;
+#pragma warning restore IDE0018 // Inline variable declaration
 			_allUnambiguousListValueCache.TryGetValue(name, out val);
 			return val;
         }

--- a/Packages/Ink/InkLibs/InkRuntime/NativeFunctionCall.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/NativeFunctionCall.cs
@@ -136,7 +136,9 @@ namespace Ink.Runtime
 
             if (paramCount == 2 || paramCount == 1) {
 
+#pragma warning disable IDE0018 // Inline variable declaration
                 object opForTypeObj = null;
+#pragma warning restore IDE0018 // Inline variable declaration
                 if (!_operationFuncs.TryGetValue (valType, out opForTypeObj)) {
                     throw new StoryException ("Cannot perform operation '"+this.name+"' on "+valType);
                 }
@@ -221,7 +223,9 @@ namespace Ink.Runtime
                     }
                 }
                 if (itemOrigin != null) {
+#pragma warning disable IDE0018 // Inline variable declaration
                     InkListItem incrementedItem;
+#pragma warning restore IDE0018 // Inline variable declaration
                     if (itemOrigin.TryGetItemWithValue (targetInt, out incrementedItem))
                         resultRawList.Add (incrementedItem, targetInt);
                 }
@@ -266,7 +270,9 @@ namespace Ink.Runtime
                         int intVal = (int)val.valueObject;
                         var list = specialCaseList.value.originOfMaxItem;
 
+#pragma warning disable IDE0018 // Inline variable declaration
                         InkListItem item;
+#pragma warning restore IDE0018 // Inline variable declaration
                         if (list.TryGetItemWithValue (intVal, out item)) {
                             var castedValue = new ListValue (item, intVal);
                             parametersOut.Add (castedValue);
@@ -445,7 +451,9 @@ namespace Ink.Runtime
 
         static void AddOpToNativeFunc(string name, int args, ValueType valType, object op)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
             NativeFunctionCall nativeFunc = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (!_nativeFunctions.TryGetValue (name, out nativeFunc)) {
                 nativeFunc = new NativeFunctionCall (name, args);
                 _nativeFunctions [name] = nativeFunc;

--- a/Packages/Ink/InkLibs/InkRuntime/NativeFunctionCall.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/NativeFunctionCall.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 
 namespace Ink.Runtime

--- a/Packages/Ink/InkLibs/InkRuntime/NativeFunctionCall.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/NativeFunctionCall.cs
@@ -498,7 +498,9 @@ namespace Ink.Runtime
         delegate object UnaryOp<T>(T val);
 
         NativeFunctionCall _prototype;
+#pragma warning disable IDE0044 // Add readonly modifier
         bool _isPrototype;
+#pragma warning restore IDE0044 // Add readonly modifier
 
         // Operations for each data type, for a single operation (e.g. "+")
         Dictionary<ValueType, object> _operationFuncs;

--- a/Packages/Ink/InkLibs/InkRuntime/NativeFunctionCall.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/NativeFunctionCall.cs
@@ -137,7 +137,9 @@ namespace Ink.Runtime
             if (paramCount == 2 || paramCount == 1) {
 
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 object opForTypeObj = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
                 if (!_operationFuncs.TryGetValue (valType, out opForTypeObj)) {
                     throw new StoryException ("Cannot perform operation '"+this.name+"' on "+valType);
@@ -452,7 +454,9 @@ namespace Ink.Runtime
         static void AddOpToNativeFunc(string name, int args, ValueType valType, object op)
         {
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             NativeFunctionCall nativeFunc = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             if (!_nativeFunctions.TryGetValue (name, out nativeFunc)) {
                 nativeFunc = new NativeFunctionCall (name, args);

--- a/Packages/Ink/InkLibs/InkRuntime/Object.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Object.cs
@@ -84,7 +84,9 @@ namespace Ink.Runtime
 
                         while (container) {
 
+#pragma warning disable IDE0019 // Use pattern matching
                             var namedChild = child as INamedContent;
+#pragma warning restore IDE0019 // Use pattern matching
                             if (namedChild != null && namedChild.hasValidName) {
                                 comps.Push (new Path.Component (namedChild.name));
                             } else {

--- a/Packages/Ink/InkLibs/InkRuntime/Object.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Object.cs
@@ -224,7 +224,9 @@ namespace Ink.Runtime
         /// if( myObj != null ) ...
         public static implicit operator bool (Object obj)
         {
+#pragma warning disable IDE0041 // Use 'is null' check
             var isNull = object.ReferenceEquals (obj, null);
+#pragma warning restore IDE0041 // Use 'is null' check
             return !isNull;
         }
 

--- a/Packages/Ink/InkLibs/InkRuntime/Object.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Object.cs
@@ -167,8 +167,10 @@ namespace Ink.Runtime
         // Find most compact representation for a path, whether relative or global
         public string CompactPathString(Path otherPath)
         {
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             string globalPathStr = null;
             string relativePathStr = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
             if (otherPath.isRelative) {
                 relativePathStr = otherPath.componentsString;
                 globalPathStr = this.path.PathByAppendingPath(otherPath).componentsString;

--- a/Packages/Ink/InkLibs/InkRuntime/Object.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Object.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE1006
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/Packages/Ink/InkLibs/InkRuntime/Path.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Path.cs
@@ -165,7 +165,9 @@ namespace Ink.Runtime
 
         public static Path self {
             get {
+#pragma warning disable IDE0017 // Simplify object initialization
                 var path = new Path ();
+#pragma warning restore IDE0017 // Simplify object initialization
                 path.isRelative = true;
                 return path;
             }
@@ -238,7 +240,9 @@ namespace Ink.Runtime
 
                 var componentStrings = _componentsString.Split('.');
                 foreach (var str in componentStrings) {
+#pragma warning disable IDE0018 // Inline variable declaration
                     int index;
+#pragma warning restore IDE0018 // Inline variable declaration
                     if (int.TryParse (str , out index)) {
                         _components.Add (new Component (index));
                     } else {

--- a/Packages/Ink/InkLibs/InkRuntime/Path.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Path.cs
@@ -10,7 +10,9 @@ namespace Ink.Runtime
 {
     public class Path : IEquatable<Path>
 	{
+#pragma warning disable IDE0044 // Add readonly modifier
         static string parentId = "^";
+#pragma warning restore IDE0044 // Add readonly modifier
 
         // Immutable Component
         public class Component : IEquatable<Component>
@@ -273,7 +275,9 @@ namespace Ink.Runtime
             return this.ToString ().GetHashCode ();
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
 		List<Component> _components;
+#pragma warning restore IDE0044 // Add readonly modifier
 	}
 }
 

--- a/Packages/Ink/InkLibs/InkRuntime/Path.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Path.cs
@@ -173,7 +173,9 @@ namespace Ink.Runtime
 
 		public Path PathByAppendingPath(Path pathToAppend)
 		{
+#pragma warning disable IDE0090 // Use 'new(...)'
             Path p = new Path ();
+#pragma warning restore IDE0090 // Use 'new(...)'
 
             int upwardMoves = 0;
             for (int i = 0; i < pathToAppend._components.Count; ++i) {
@@ -197,7 +199,9 @@ namespace Ink.Runtime
 
         public Path PathByAppendingComponent (Component c)
         {
+#pragma warning disable IDE0090 // Use 'new(...)'
             Path p = new Path ();
+#pragma warning restore IDE0090 // Use 'new(...)'
             p._components.AddRange (_components);
             p._components.Add (c);
             return p;

--- a/Packages/Ink/InkLibs/InkRuntime/Path.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Path.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;

--- a/Packages/Ink/InkLibs/InkRuntime/Pointer.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Pointer.cs
@@ -66,7 +66,9 @@ namespace Ink.Runtime
             };
         }
 
+#pragma warning disable IDE0090 // Use 'new(...)'
         public static Pointer Null = new Pointer { container = null, index = -1 };
+#pragma warning restore IDE0090 // Use 'new(...)'
 
 	}
 }

--- a/Packages/Ink/InkLibs/InkRuntime/Pointer.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Pointer.cs
@@ -1,4 +1,6 @@
-﻿using Ink.Runtime;
+﻿#pragma warning disable IDE1006
+
+using Ink.Runtime;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
@@ -92,7 +92,9 @@ namespace Ink.Runtime
 
 			var currObj = callstack.currentElement.currentPointer.Resolve();
 
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
 			string stepType = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 			var controlCommandStep = currObj as ControlCommand;
 			if( controlCommandStep )
 				stepType = controlCommandStep.commandType.ToString() + " CC";

--- a/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
@@ -216,13 +216,19 @@ namespace Ink.Runtime
 		}
 
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		Stopwatch _continueWatch = new Stopwatch();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		Stopwatch _stepWatch = new Stopwatch();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		Stopwatch _snapWatch = new Stopwatch();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 
 		double _continueTotal;
@@ -242,7 +248,9 @@ namespace Ink.Runtime
 			public double time;
 		}
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
 		List<StepDetails> _stepDetails = new List<StepDetails>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 
 #pragma warning disable IDE0044 // Add readonly modifier

--- a/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Text;

--- a/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
@@ -215,9 +215,15 @@ namespace Ink.Runtime
 			}
 		}
 
+#pragma warning disable IDE0044 // Add readonly modifier
 		Stopwatch _continueWatch = new Stopwatch();
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
 		Stopwatch _stepWatch = new Stopwatch();
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
 		Stopwatch _snapWatch = new Stopwatch();
+#pragma warning restore IDE0044 // Add readonly modifier
 
 		double _continueTotal;
 		double _snapTotal;
@@ -225,7 +231,9 @@ namespace Ink.Runtime
 
 		string[] _currStepStack;
 		StepDetails _currStepDetails;
+#pragma warning disable IDE0044 // Add readonly modifier
 		ProfileNode _rootNode;
+#pragma warning restore IDE0044 // Add readonly modifier
 		int _numContinues;
 
 		struct StepDetails {
@@ -233,9 +241,13 @@ namespace Ink.Runtime
 			public Runtime.Object obj;
 			public double time;
 		}
+#pragma warning disable IDE0044 // Add readonly modifier
 		List<StepDetails> _stepDetails = new List<StepDetails>();
+#pragma warning restore IDE0044 // Add readonly modifier
 
+#pragma warning disable IDE0044 // Add readonly modifier
 		static double _millisecsPerTick = 1000.0 / Stopwatch.Frequency;
+#pragma warning restore IDE0044 // Add readonly modifier
 	}
 
 

--- a/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Profiler.cs
@@ -331,7 +331,9 @@ namespace Ink.Runtime
 			var nodeKey = stack[stackIdx];
 			if( _nodes == null ) _nodes = new Dictionary<string, ProfileNode>();
 
+#pragma warning disable IDE0018 // Inline variable declaration
 			ProfileNode node;
+#pragma warning restore IDE0018 // Inline variable declaration
 			if( !_nodes.TryGetValue(nodeKey, out node) ) {
 				node = new ProfileNode(nodeKey);
 				_nodes[nodeKey] = node;

--- a/Packages/Ink/InkLibs/InkRuntime/SearchResult.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/SearchResult.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 namespace Ink.Runtime
 {
     // When looking up content within the story (e.g. in Container.ContentAtPath),

--- a/Packages/Ink/InkLibs/InkRuntime/SimpleJson.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/SimpleJson.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Text;
 using System.Collections.Generic;
 using System.IO;

--- a/Packages/Ink/InkLibs/InkRuntime/SimpleJson.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/SimpleJson.cs
@@ -644,7 +644,9 @@ namespace Ink.Runtime
             }
 
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
             Stack<StateElement> _stateStack = new Stack<StateElement>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
             TextWriter _writer;

--- a/Packages/Ink/InkLibs/InkRuntime/SimpleJson.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/SimpleJson.cs
@@ -297,10 +297,14 @@ namespace Ink.Runtime
                 }
             }
 
+#pragma warning disable IDE0044 // Add readonly modifier
             string _text;
+#pragma warning restore IDE0044 // Add readonly modifier
             int _offset;
 
+#pragma warning disable IDE0044 // Add readonly modifier
             object _rootObject;
+#pragma warning restore IDE0044 // Add readonly modifier
         }
 
 
@@ -639,8 +643,12 @@ namespace Ink.Runtime
                 public int childCount;
             }
 
+#pragma warning disable IDE0044 // Add readonly modifier
             Stack<StateElement> _stateStack = new Stack<StateElement>();
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
             TextWriter _writer;
+#pragma warning restore IDE0044 // Add readonly modifier
         }
 
 

--- a/Packages/Ink/InkLibs/InkRuntime/SimpleJson.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/SimpleJson.cs
@@ -237,12 +237,16 @@ namespace Ink.Runtime
                 string numStr = _text.Substring (startOffset, _offset - startOffset);
 
                 if (isFloat) {
+#pragma warning disable IDE0018 // Inline variable declaration
                     float f;
+#pragma warning restore IDE0018 // Inline variable declaration
                     if (float.TryParse (numStr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out f)) {
                         return f;
                     }
                 } else {
+#pragma warning disable IDE0018 // Inline variable declaration
                     int i;
+#pragma warning restore IDE0018 // Inline variable declaration
                     if (int.TryParse (numStr, out i)) {
                         return i;
                     }

--- a/Packages/Ink/InkLibs/InkRuntime/StatePatch.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/StatePatch.cs
@@ -60,9 +60,17 @@ namespace Ink.Runtime
             return _turnIndices.TryGetValue(container, out index);
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         Dictionary<string, Runtime.Object> _globals;
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         HashSet<string> _changedVariables = new HashSet<string>();
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         Dictionary<Container, int> _visitCounts = new Dictionary<Container, int>();
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         Dictionary<Container, int> _turnIndices = new Dictionary<Container, int>();
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/Packages/Ink/InkLibs/InkRuntime/StatePatch.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/StatePatch.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable IDE1006
+
+using System.Collections.Generic;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/StatePatch.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/StatePatch.cs
@@ -64,13 +64,19 @@ namespace Ink.Runtime
         Dictionary<string, Runtime.Object> _globals;
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         HashSet<string> _changedVariables = new HashSet<string>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         Dictionary<Container, int> _visitCounts = new Dictionary<Container, int>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         Dictionary<Container, int> _turnIndices = new Dictionary<Container, int>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -1252,7 +1252,9 @@ namespace Ink.Runtime
                     }
                     else if (state.callStack.currentElement.type != popType || !state.callStack.canPop) {
 
+#pragma warning disable IDE0028 // Simplify collection initialization
                         var names = new Dictionary<PushPopType, string> ();
+#pragma warning restore IDE0028 // Simplify collection initialization
                         names [PushPopType.Function] = "function return statement (~ return)";
                         names [PushPopType.Tunnel] = "tunnel onwards statement (->->)";
 
@@ -1522,7 +1524,9 @@ namespace Ink.Runtime
                             var randomItem = listEnumerator.Current;
 
                             // Origin list is simply the origin of the one element
+#pragma warning disable IDE0028 // Simplify collection initialization
                             newList = new InkList (randomItem.Key.originName, this);
+#pragma warning restore IDE0028 // Simplify collection initialization
                             newList.Add (randomItem.Key, randomItem.Value);
 
                             state.previousRandom = nextRandom;

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -965,7 +965,9 @@ namespace Ink.Runtime
         }
 
 #pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
         List<Container> _prevContainers = new List<Container>();
+#pragma warning restore IDE0090 // Use 'new(...)'
 #pragma warning restore IDE0044 // Add readonly modifier
         void VisitChangedContainersDueToDivert()
         {

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -506,7 +506,9 @@ namespace Ink.Runtime
                     _state.variablesState.batchObservingVariableChanges = false;
 
                 _asyncContinueActive = false;
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
                 if(onDidContinue != null) onDidContinue();
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
             }
 
             _recursiveContinueCount--;
@@ -1620,7 +1622,9 @@ namespace Ink.Runtime
         public void ChoosePathString (string path, bool resetCallstack = true, params object [] arguments)
         {
             IfAsyncWeCant ("call ChoosePathString right now");
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
             if(onChoosePathString != null) onChoosePathString(path, arguments);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
             if (resetCallstack) {
                 ResetCallstack ();
             } else {
@@ -1670,7 +1674,9 @@ namespace Ink.Runtime
             // can create multiple leading edges for the story, each of
             // which has its own context.
             var choiceToChoose = choices [choiceIdx];
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
             if(onMakeChoice != null) onMakeChoice(choiceToChoose);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
             state.callStack.currentThread = choiceToChoose.threadAtGeneration;
 
             ChoosePath (choiceToChoose.targetPath);
@@ -1712,7 +1718,9 @@ namespace Ink.Runtime
         /// <param name="arguments">The arguments that the ink function takes, if any. Note that we don't (can't) do any validation on the number of arguments right now, so make sure you get it right!</param>
         public object EvaluateFunction (string functionName, out string textOutput, params object [] arguments)
         {
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
             if(onEvaluateFunction != null) onEvaluateFunction(functionName, arguments);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
             IfAsyncWeCant ("evaluate a function");
 
 			if(functionName == null) {
@@ -1746,7 +1754,9 @@ namespace Ink.Runtime
 
             // Finish evaluation, and see whether anything was produced
             var result = state.CompleteFunctionEvaluationFromGame ();
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
             if(onCompleteEvaluateFunction != null) onCompleteEvaluateFunction(functionName, arguments, textOutput, result);
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
             return result;
         }
 

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE1006
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -964,7 +964,9 @@ namespace Ink.Runtime
             }
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         List<Container> _prevContainers = new List<Container>();
+#pragma warning restore IDE0044 // Add readonly modifier
         void VisitChangedContainersDueToDivert()
         {
             var previousPointer = state.previousPointer;
@@ -2746,14 +2748,20 @@ namespace Ink.Runtime
             }
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         Container _mainContentContainer;
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning disable IDE0044 // Add readonly modifier
         ListDefinitionsOrigin _listDefinitions;
+#pragma warning restore IDE0044 // Add readonly modifier
 
         struct ExternalFunctionDef {
             public ExternalFunction function;
             public bool lookaheadSafe;
         }
+#pragma warning disable IDE0044 // Add readonly modifier
         Dictionary<string, ExternalFunctionDef> _externals;
+#pragma warning restore IDE0044 // Add readonly modifier
         Dictionary<string, VariableObserver> _variableObservers;
         bool _hasValidatedExternals;
 

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -1904,25 +1904,35 @@ namespace Ink.Runtime
             if (value == null)
                 return null;
 
+#pragma warning disable IDE0038 // Use pattern matching
             if (value is T)
+#pragma warning restore IDE0038 // Use pattern matching
                 return (T) value;
 
+#pragma warning disable IDE0038 // Use pattern matching
             if (value is float && typeof(T) == typeof(int)) {
+#pragma warning restore IDE0038 // Use pattern matching
                 int intVal = (int)Math.Round ((float)value);
                 return intVal;
             }
 
+#pragma warning disable IDE0038 // Use pattern matching
             if (value is int && typeof(T) == typeof(float)) {
+#pragma warning restore IDE0038 // Use pattern matching
                 float floatVal = (float)(int)value;
                 return floatVal;
             }
 
+#pragma warning disable IDE0038 // Use pattern matching
             if (value is int && typeof(T) == typeof(bool)) {
+#pragma warning restore IDE0038 // Use pattern matching
                 int intVal = (int)value;
                 return intVal == 0 ? false : true;
             }
 
+#pragma warning disable IDE0038 // Use pattern matching
             if (value is bool && typeof(T) == typeof(int)) {
+#pragma warning restore IDE0038 // Use pattern matching
                 bool boolVal = (bool)value;
                 return boolVal ? 1 : 0;
             }
@@ -2421,7 +2431,9 @@ namespace Ink.Runtime
             var flowContainer = ContentAtPath (path).container;
             while(true) {
                 var firstContent = flowContainer.content [0];
+#pragma warning disable IDE0038 // Use pattern matching
                 if (firstContent is Container)
+#pragma warning restore IDE0038 // Use pattern matching
                     flowContainer = (Container)firstContent;
                 else break;
             }

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -2489,7 +2489,9 @@ namespace Ink.Runtime
             return sb.ToString ();
         }
 
+#pragma warning disable IDE0051 // Remove unused private members
         string BuildStringOfContainer (Container container)
+#pragma warning restore IDE0051 // Remove unused private members
         {
         	var sb = new StringBuilder ();
 
@@ -2765,7 +2767,9 @@ namespace Ink.Runtime
             }
         }
 
+#pragma warning disable IDE0051 // Remove unused private members
         int currentLineNumber 
+#pragma warning restore IDE0051 // Remove unused private members
         {
             get {
                 var dm = currentDebugMetadata;

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -1093,10 +1093,14 @@ namespace Ink.Runtime
         {
             bool truthy = false;
             if (obj is Value) {
+#pragma warning disable IDE0020 // Use pattern matching
                 var val = (Value)obj;
+#pragma warning restore IDE0020 // Use pattern matching
 
                 if (val is DivertTargetValue) {
+#pragma warning disable IDE0020 // Use pattern matching
                     var divTarget = (DivertTargetValue)val;
+#pragma warning restore IDE0020 // Use pattern matching
                     Error ("Shouldn't use a divert target (to " + divTarget.targetPath + ") as a conditional value. Did you intend a function call 'likeThis()' or a read count check 'likeThis'? (no arrows)");
                     return false;
                 }
@@ -1121,7 +1125,9 @@ namespace Ink.Runtime
             // Divert
             if (contentObj is Divert) {
                 
+#pragma warning disable IDE0020 // Use pattern matching
                 Divert currentDivert = (Divert)contentObj;
+#pragma warning restore IDE0020 // Use pattern matching
 
                 if (currentDivert.isConditional) {
                     var conditionValue = state.PopEvaluationStack ();
@@ -1185,7 +1191,9 @@ namespace Ink.Runtime
 
             // Start/end an expression evaluation? Or print out the result?
             else if( contentObj is ControlCommand ) {
+#pragma warning disable IDE0020 // Use pattern matching
                 var evalCommand = (ControlCommand) contentObj;
+#pragma warning restore IDE0020 // Use pattern matching
 
                 switch (evalCommand.commandType) {
 
@@ -1546,7 +1554,9 @@ namespace Ink.Runtime
 
             // Variable assignment
             else if( contentObj is VariableAssignment ) {
+#pragma warning disable IDE0020 // Use pattern matching
                 var varAss = (VariableAssignment) contentObj;
+#pragma warning restore IDE0020 // Use pattern matching
                 var assignedVal = state.PopEvaluationStack();
 
                 // When in temporary evaluation, don't create new variables purely within
@@ -1560,7 +1570,9 @@ namespace Ink.Runtime
 
             // Variable reference
             else if( contentObj is VariableReference ) {
+#pragma warning disable IDE0020 // Use pattern matching
                 var varRef = (VariableReference)contentObj;
+#pragma warning restore IDE0020 // Use pattern matching
 #pragma warning disable IDE0059 // Unnecessary assignment of a value
                 Runtime.Object foundValue = null;
 #pragma warning restore IDE0059 // Unnecessary assignment of a value
@@ -1592,7 +1604,9 @@ namespace Ink.Runtime
 
             // Native function call
             else if (contentObj is NativeFunctionCall) {
+#pragma warning disable IDE0020 // Use pattern matching
                 var func = (NativeFunctionCall)contentObj;
+#pragma warning restore IDE0020 // Use pattern matching
                 var funcParams = state.PopEvaluationStack (func.numberOfParameters);
                 var result = func.Call (funcParams);
                 state.PushEvaluationStack (result);

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -219,7 +219,9 @@ namespace Ink.Runtime
             if (rootToken == null)
                 throw new System.Exception ("Root node for ink not found. Are you sure it's a valid .ink.json file?");
 
+#pragma warning disable IDE0018 // Inline variable declaration
             object listDefsObj;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (rootObject.TryGetValue ("listDefs", out listDefsObj)) {
                 _listDefinitions = Json.JTokenToListDefinitions (listDefsObj);
             }
@@ -725,7 +727,9 @@ namespace Ink.Runtime
 
         public Runtime.Container KnotContainerWithName (string name)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
             INamedContent namedContainer;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (mainContentContainer.namedContent.TryGetValue (name, out namedContainer))
                 return namedContainer as Container;
             else
@@ -1061,7 +1065,9 @@ namespace Ink.Runtime
                 return null;
             }
 
+#pragma warning disable IDE0017 // Simplify object initialization
             var choice = new Choice ();
+#pragma warning restore IDE0017 // Simplify object initialization
             choice.targetPath = choicePoint.pathOnChoice;
             choice.sourcePath = choicePoint.path.ToString ();
             choice.isInvisibleDefault = choicePoint.isInvisibleDefault;
@@ -1451,7 +1457,9 @@ namespace Ink.Runtime
 
                     ListDefinition foundListDef;
                     if (listDefinitions.TryListGetDefinition (listNameVal.value, out foundListDef)) {
+#pragma warning disable IDE0018 // Inline variable declaration
                         InkListItem foundItem;
+#pragma warning restore IDE0018 // Inline variable declaration
                         if (foundListDef.TryGetItemWithValue (intVal.value, out foundItem)) {
                             generatedListValue = new ListValue (foundItem, intVal.value);
                         }
@@ -1808,7 +1816,9 @@ namespace Ink.Runtime
 
         public void CallExternalFunction(string funcName, int numberOfArguments)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
             ExternalFunctionDef funcDef;
+#pragma warning restore IDE0018 // Inline variable declaration
             Container fallbackFunctionContainer = null;
 
             var foundExternal = _externals.TryGetValue (funcName, out funcDef);
@@ -2390,7 +2400,9 @@ namespace Ink.Runtime
             if (_variableObservers == null)
                 return;
             
+#pragma warning disable IDE0018 // Inline variable declaration
             VariableObserver observers = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (_variableObservers.TryGetValue (variableName, out observers)) {
 
                 if (!(newValueObj is Value)) {
@@ -2655,7 +2667,9 @@ namespace Ink.Runtime
         // then exits the flow.
         public void Error(string message, bool useEndLineNumber = false)
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             var e = new StoryException (message);
+#pragma warning restore IDE0017 // Simplify object initialization
             e.useEndLineNumber = useEndLineNumber;
             throw e;
         }

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -1496,7 +1496,9 @@ namespace Ink.Runtime
                         
                         var list = listVal.value;
 
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                         InkList newList = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
                         // List was empty: return empty list
                         if (list.Count == 0) {
@@ -1555,7 +1557,9 @@ namespace Ink.Runtime
             // Variable reference
             else if( contentObj is VariableReference ) {
                 var varRef = (VariableReference)contentObj;
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 Runtime.Object foundValue = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
 
                 // Explicit read count value
@@ -1865,7 +1869,9 @@ namespace Ink.Runtime
             object funcResult = funcDef.function (arguments.ToArray());
 
             // Convert return value (if any) to the a type that the ink engine can use
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             Runtime.Object returnObj = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
             if (funcResult != null) {
                 returnObj = Value.Create (funcResult);
                 Assert (returnObj != null, "Could not create ink value from returned object of type " + funcResult.GetType());
@@ -2401,7 +2407,9 @@ namespace Ink.Runtime
                 return;
             
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             VariableObserver observers = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             if (_variableObservers.TryGetValue (variableName, out observers)) {
 

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -1943,7 +1943,9 @@ namespace Ink.Runtime
             if (value is int && typeof(T) == typeof(bool)) {
 #pragma warning restore IDE0038 // Use pattern matching
                 int intVal = (int)value;
+#pragma warning disable IDE0075 // Simplify conditional expression
                 return intVal == 0 ? false : true;
+#pragma warning restore IDE0075 // Simplify conditional expression
             }
 
 #pragma warning disable IDE0038 // Use pattern matching

--- a/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
@@ -55,7 +55,9 @@ namespace Ink.Runtime
         {
             var jObject = SimpleJson.TextToDictionary (json);
             LoadJsonObj(jObject);
+#pragma warning disable IDE1005 // Delegate invocation can be simplified.
             if(onDidLoadState != null) onDidLoadState();
+#pragma warning restore IDE1005 // Delegate invocation can be simplified.
         }
 
         /// <summary>

--- a/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics;

--- a/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
@@ -413,7 +413,9 @@ namespace Ink.Runtime
             if(flowName == null) throw new System.Exception("Must pass a non-null string to Story.SwitchFlow");
             
             if( _namedFlows == null ) {
+#pragma warning disable IDE0028 // Simplify collection initialization
                 _namedFlows = new Dictionary<string, Flow>();
+#pragma warning restore IDE0028 // Simplify collection initialization
                 _namedFlows[kDefaultFlowName] = _currentFlow;
             }
 

--- a/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
@@ -100,7 +100,9 @@ namespace Ink.Runtime
             }
 
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             int count = 0;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             if (_patch != null && _patch.TryGetVisitCount(container, out count))
                 return count;
@@ -120,7 +122,9 @@ namespace Ink.Runtime
             }
 
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             int count = 0;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             var containerPathStr = container.path.ToString();
             _visitCounts.TryGetValue(containerPathStr, out count);
@@ -147,7 +151,9 @@ namespace Ink.Runtime
             }
 
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             int index = 0;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
 
             if ( _patch != null && _patch.TryGetTurnIndex(container, out index) ) {
@@ -603,7 +609,9 @@ namespace Ink.Runtime
         void LoadJsonObj(Dictionary<string, object> jObject)
         {
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
 			object jSaveVersion = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
 			if (!jObject.TryGetValue("inkSaveVersion", out jSaveVersion)) {
                 throw new Exception ("ink save format incorrect, can't load.");
@@ -615,7 +623,9 @@ namespace Ink.Runtime
             // Flows: Always exists in latest format (even if there's just one default)
             // but this dictionary doesn't exist in prev format
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             object flowsObj = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             if (jObject.TryGetValue("flows", out flowsObj)) {
                 var flowsObjDict = (Dictionary<string, object>)flowsObj;
@@ -662,7 +672,9 @@ namespace Ink.Runtime
                 _currentFlow.currentChoices = Json.JArrayToRuntimeObjList<Choice>((List<object>)jObject ["currentChoices"]);
 
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 object jChoiceThreadsObj = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
                 jObject.TryGetValue("choiceThreads", out jChoiceThreadsObj);
                 _currentFlow.LoadFlowChoiceThreads((Dictionary<string, object>)jChoiceThreadsObj, story);
@@ -692,7 +704,9 @@ namespace Ink.Runtime
 
             // Not optional, but bug in inkjs means it's actually missing in inkjs saves
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             object previousRandomObj = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             if( jObject.TryGetValue("previousRandom", out previousRandomObj) ) {
                 previousRandom = (int)previousRandomObj;
@@ -879,7 +893,9 @@ namespace Ink.Runtime
                 }
 
                 // Where is the most agressive (earliest) trim point?
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 var trimIndex = -1;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
                 if (glueTrimIndex != -1 && functionTrimIndex != -1)
                     trimIndex = Math.Min (functionTrimIndex, glueTrimIndex);
                 else if (glueTrimIndex != -1)
@@ -1049,7 +1065,9 @@ namespace Ink.Runtime
 
 					foreach (var n in rawList.originNames) {
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                         ListDefinition def = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
                         story.listDefinitions.TryListGetDefinition (n, out def);
 						if( !rawList.origins.Contains(def) )

--- a/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/StoryState.cs
@@ -99,7 +99,9 @@ namespace Ink.Runtime
                 return 0;
             }
 
+#pragma warning disable IDE0018 // Inline variable declaration
             int count = 0;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (_patch != null && _patch.TryGetVisitCount(container, out count))
                 return count;
                 
@@ -117,7 +119,9 @@ namespace Ink.Runtime
                 return;
             }
 
+#pragma warning disable IDE0018 // Inline variable declaration
             int count = 0;
+#pragma warning restore IDE0018 // Inline variable declaration
             var containerPathStr = container.path.ToString();
             _visitCounts.TryGetValue(containerPathStr, out count);
             count++;
@@ -142,7 +146,9 @@ namespace Ink.Runtime
                 story.Error("TURNS_SINCE() for target (" + container.name + " - on " + container.debugMetadata + ") unknown.");
             }
 
+#pragma warning disable IDE0018 // Inline variable declaration
             int index = 0;
+#pragma warning restore IDE0018 // Inline variable declaration
 
             if ( _patch != null && _patch.TryGetTurnIndex(container, out index) ) {
                 return currentTurnIndex - index;
@@ -409,7 +415,9 @@ namespace Ink.Runtime
                 return;
             }
 
+#pragma warning disable IDE0018 // Inline variable declaration
             Flow flow;
+#pragma warning restore IDE0018 // Inline variable declaration
             if( !_namedFlows.TryGetValue(flowName, out flow) ) {
                 flow = new Flow(flowName, story);
                 _namedFlows[flowName] = flow;
@@ -448,7 +456,9 @@ namespace Ink.Runtime
         // I wonder if there's a sensible way to enforce that..??
         public StoryState CopyAndStartPatching()
         {
+#pragma warning disable IDE0017 // Simplify object initialization
             var copy = new StoryState(story);
+#pragma warning restore IDE0017 // Simplify object initialization
 
             copy._patch = new StatePatch(_patch);
 
@@ -592,7 +602,9 @@ namespace Ink.Runtime
 
         void LoadJsonObj(Dictionary<string, object> jObject)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
 			object jSaveVersion = null;
+#pragma warning restore IDE0018 // Inline variable declaration
 			if (!jObject.TryGetValue("inkSaveVersion", out jSaveVersion)) {
                 throw new Exception ("ink save format incorrect, can't load.");
             }
@@ -602,7 +614,9 @@ namespace Ink.Runtime
 
             // Flows: Always exists in latest format (even if there's just one default)
             // but this dictionary doesn't exist in prev format
+#pragma warning disable IDE0018 // Inline variable declaration
             object flowsObj = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             if (jObject.TryGetValue("flows", out flowsObj)) {
                 var flowsObjDict = (Dictionary<string, object>)flowsObj;
                 
@@ -647,7 +661,9 @@ namespace Ink.Runtime
                 _currentFlow.outputStream = Json.JArrayToRuntimeObjList ((List<object>)jObject ["outputStream"]);
                 _currentFlow.currentChoices = Json.JArrayToRuntimeObjList<Choice>((List<object>)jObject ["currentChoices"]);
 
+#pragma warning disable IDE0018 // Inline variable declaration
                 object jChoiceThreadsObj = null;
+#pragma warning restore IDE0018 // Inline variable declaration
                 jObject.TryGetValue("choiceThreads", out jChoiceThreadsObj);
                 _currentFlow.LoadFlowChoiceThreads((Dictionary<string, object>)jChoiceThreadsObj, story);
             }
@@ -660,7 +676,9 @@ namespace Ink.Runtime
             evaluationStack = Json.JArrayToRuntimeObjList ((List<object>)jObject ["evalStack"]);
 
 
+#pragma warning disable IDE0018 // Inline variable declaration
 			object currentDivertTargetPath;
+#pragma warning restore IDE0018 // Inline variable declaration
 			if (jObject.TryGetValue("currentDivertTarget", out currentDivertTargetPath)) {
                 var divertPath = new Path (currentDivertTargetPath.ToString ());
                 divertedPointer = story.PointerAtPath (divertPath);
@@ -673,7 +691,9 @@ namespace Ink.Runtime
             storySeed = (int)jObject ["storySeed"];
 
             // Not optional, but bug in inkjs means it's actually missing in inkjs saves
+#pragma warning disable IDE0018 // Inline variable declaration
             object previousRandomObj = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             if( jObject.TryGetValue("previousRandom", out previousRandomObj) ) {
                 previousRandom = (int)previousRandomObj;
             } else {
@@ -1028,7 +1048,9 @@ namespace Ink.Runtime
 					rawList.origins.Clear();
 
 					foreach (var n in rawList.originNames) {
+#pragma warning disable IDE0018 // Inline variable declaration
                         ListDefinition def = null;
+#pragma warning restore IDE0018 // Inline variable declaration
                         story.listDefinitions.TryListGetDefinition (n, out def);
 						if( !rawList.origins.Contains(def) )
 							rawList.origins.Add (def);

--- a/Packages/Ink/InkLibs/InkRuntime/Tag.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Tag.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/Value.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Value.cs
@@ -170,7 +170,9 @@ namespace Ink.Runtime
             }
 
             if (newType == ValueType.Bool) {
+#pragma warning disable IDE0075 // Simplify conditional expression
                 return new BoolValue (this.value == 0 ? false : true);
+#pragma warning restore IDE0075 // Simplify conditional expression
             }
 
             if (newType == ValueType.Float) {
@@ -203,7 +205,9 @@ namespace Ink.Runtime
             }
 
             if (newType == ValueType.Bool) {
+#pragma warning disable IDE0075 // Simplify conditional expression
                 return new BoolValue (this.value == 0.0f ? false : true);
+#pragma warning restore IDE0075 // Simplify conditional expression
             }
 
             if (newType == ValueType.Int) {

--- a/Packages/Ink/InkLibs/InkRuntime/Value.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Value.cs
@@ -44,21 +44,37 @@ namespace Ink.Runtime
                 val = (float)doub;
             }
 
+#pragma warning disable IDE0038 // Use pattern matching
             if( val is bool ) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return new BoolValue((bool)val);
+#pragma warning disable IDE0038 // Use pattern matching
             } else if (val is int) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return new IntValue ((int)val);
+#pragma warning disable IDE0038 // Use pattern matching
             } else if (val is long) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return new IntValue ((int)(long)val);
+#pragma warning disable IDE0038 // Use pattern matching
             } else if (val is float) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return new FloatValue ((float)val);
+#pragma warning disable IDE0038 // Use pattern matching
             } else if (val is double) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return new FloatValue ((float)(double)val);
+#pragma warning disable IDE0038 // Use pattern matching
             } else if (val is string) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return new StringValue ((string)val);
+#pragma warning disable IDE0038 // Use pattern matching
             } else if (val is Path) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return new DivertTargetValue ((Path)val);
+#pragma warning disable IDE0038 // Use pattern matching
             } else if (val is InkList) {
+#pragma warning restore IDE0038 // Use pattern matching
                 return new ListValue ((InkList)val);
             }
 

--- a/Packages/Ink/InkLibs/InkRuntime/Value.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Value.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿#pragma warning disable IDE1006
+
+using System.ComponentModel;
 using System.Collections.Generic;
 
 namespace Ink.Runtime

--- a/Packages/Ink/InkLibs/InkRuntime/Value.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Value.cs
@@ -254,7 +254,9 @@ namespace Ink.Runtime
 
             if (newType == ValueType.Int) {
 
+#pragma warning disable IDE0018 // Inline variable declaration
                 int parsedInt;
+#pragma warning restore IDE0018 // Inline variable declaration
                 if (int.TryParse (value, out parsedInt)) {
                     return new IntValue (parsedInt);
                 } else {
@@ -263,7 +265,9 @@ namespace Ink.Runtime
             }
 
             if (newType == ValueType.Float) {
+#pragma warning disable IDE0018 // Inline variable declaration
                 float parsedFloat;
+#pragma warning restore IDE0018 // Inline variable declaration
                 if (float.TryParse (value, System.Globalization.NumberStyles.Float ,System.Globalization.CultureInfo.InvariantCulture, out parsedFloat)) {
                     return new FloatValue (parsedFloat);
                 } else {

--- a/Packages/Ink/InkLibs/InkRuntime/Value.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Value.cs
@@ -40,7 +40,9 @@ namespace Ink.Runtime
         {
             // Implicitly lose precision from any doubles we get passed in
             if (val is double) {
+#pragma warning disable IDE0020 // Use pattern matching
                 double doub = (double)val;
+#pragma warning restore IDE0020 // Use pattern matching
                 val = (float)doub;
             }
 

--- a/Packages/Ink/InkLibs/InkRuntime/VariableAssignment.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/VariableAssignment.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿#pragma warning disable IDE1006
+
+using System.ComponentModel;
 
 namespace Ink.Runtime
 {

--- a/Packages/Ink/InkLibs/InkRuntime/VariableReference.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/VariableReference.cs
@@ -1,4 +1,6 @@
-﻿namespace Ink.Runtime
+﻿#pragma warning disable IDE1006
+
+namespace Ink.Runtime
 {
     public class VariableReference : Runtime.Object
     {

--- a/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
@@ -65,7 +65,9 @@ namespace Ink.Runtime
         public object this[string variableName]
         {
             get {
+#pragma warning disable IDE0018 // Inline variable declaration
                 Runtime.Object varContents;
+#pragma warning restore IDE0018 // Inline variable declaration
 
                 if (patch != null && patch.TryGetGlobal(variableName, out varContents))
                     return (varContents as Runtime.Value).valueObject;
@@ -137,7 +139,9 @@ namespace Ink.Runtime
             _globalVariables.Clear();
 
             foreach (var varVal in _defaultGlobalVariables) {
+#pragma warning disable IDE0018 // Inline variable declaration
                 object loadedToken;
+#pragma warning restore IDE0018 // Inline variable declaration
                 if( jToken.TryGetValue(varVal.Key, out loadedToken) ) {
                     _globalVariables[varVal.Key] = Json.JTokenToRuntimeObject(loadedToken);
                 } else {
@@ -168,7 +172,9 @@ namespace Ink.Runtime
 
                 if(dontSaveDefaultValues) {
                     // Don't write out values that are the same as the default global values
+#pragma warning disable IDE0018 // Inline variable declaration
                     Runtime.Object defaultVal;
+#pragma warning restore IDE0018 // Inline variable declaration
                     if (_defaultGlobalVariables.TryGetValue(name, out defaultVal))
                     {
                         if (RuntimeObjectsEqual(val, defaultVal))
@@ -222,7 +228,9 @@ namespace Ink.Runtime
 
         public Runtime.Object TryGetDefaultVariableValue (string name)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
             Runtime.Object val = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             _defaultGlobalVariables.TryGetValue (name, out val);
             return val;
         }
@@ -344,7 +352,9 @@ namespace Ink.Runtime
 
         public void SetGlobal(string variableName, Runtime.Object value)
         {
+#pragma warning disable IDE0018 // Inline variable declaration
             Runtime.Object oldValue = null;
+#pragma warning restore IDE0018 // Inline variable declaration
             if( patch == null || !patch.TryGetGlobal(variableName, out oldValue) )
                 _globalVariables.TryGetValue (variableName, out oldValue);
 

--- a/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
@@ -406,14 +406,18 @@ namespace Ink.Runtime
             return _callStack.currentElementIndex;
         }
 
+#pragma warning disable IDE0044 // Add readonly modifier
         Dictionary<string, Runtime.Object> _globalVariables;
+#pragma warning restore IDE0044 // Add readonly modifier
 
         Dictionary<string, Runtime.Object> _defaultGlobalVariables;
 
         // Used for accessing temporary variables
         CallStack _callStack;
         HashSet<string> _changedVariablesForBatchObs;
+#pragma warning disable IDE0044 // Add readonly modifier
         ListDefinitionsOrigin _listDefsOrigin;
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 }
 

--- a/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable IDE1006
+
+using System;
 using System.Collections.Generic;
 
 namespace Ink.Runtime

--- a/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
@@ -229,7 +229,9 @@ namespace Ink.Runtime
         public Runtime.Object TryGetDefaultVariableValue (string name)
         {
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             Runtime.Object val = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             _defaultGlobalVariables.TryGetValue (name, out val);
             return val;
@@ -255,7 +257,9 @@ namespace Ink.Runtime
 
         Runtime.Object GetRawVariableWithName(string name, int contextIndex)
         {
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             Runtime.Object varValue = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
             // 0 context = global
             if (contextIndex == 0 || contextIndex == -1) {
@@ -296,7 +300,9 @@ namespace Ink.Runtime
             int contextIndex = -1;
 
             // Are we assigning to a global variable?
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             bool setGlobal = false;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
             if (varAss.isNewDeclaration) {
                 setGlobal = varAss.isGlobal;
             } else {
@@ -318,7 +324,9 @@ namespace Ink.Runtime
             else {
 
                 // De-reference variable reference to point to
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
                 VariablePointerValue existingPointer = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
                 do {
                     existingPointer = GetRawVariableWithName (name, contextIndex) as VariablePointerValue;
                     if (existingPointer) {
@@ -353,7 +361,9 @@ namespace Ink.Runtime
         public void SetGlobal(string variableName, Runtime.Object value)
         {
 #pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             Runtime.Object oldValue = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 #pragma warning restore IDE0018 // Inline variable declaration
             if( patch == null || !patch.TryGetGlobal(variableName, out oldValue) )
                 _globalVariables.TryGetValue (variableName, out oldValue);

--- a/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
@@ -350,7 +350,9 @@ namespace Ink.Runtime
             _defaultGlobalVariables = new Dictionary<string, Object> (_globalVariables);
         }
 
+#pragma warning disable IDE0051 // Remove unused private members
         void RetainListOriginsForAssignment (Runtime.Object oldValue, Runtime.Object newValue)
+#pragma warning restore IDE0051 // Remove unused private members
         {
             var oldList = oldValue as ListValue;
             var newList = newValue as ListValue;


### PR DESCRIPTION
This PR is to help reduce the amount of messages in the error list. It is not the most graceful solution, but it keeps the original code in tact.

The commits have been separated by different warnings so that they can be looked at individually to determine if they should stay a repressed warning or if the code should be changed to take advantage of newer features.

As a side note, some functions have unused parameters. However this specific warning does not play well with being disabled and might have to be looked at a bit further. They can be found in `Packages\Ink\Editor\Core\InkEditorUtils.cs`, `Packages\Ink\InkLibs\InkCompiler\StringParser\StringParser.cs` and `Packages\Ink\Editor\Core\Compiler\Auto Compiler\InkPostProcessor.cs`. 