### PR TITLE
Choice tags support

### DIFF
--- a/Packages/Ink/InkLibs/InkRuntime/Choice.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Choice.cs
@@ -45,9 +45,12 @@ namespace Ink.Runtime
         public int originalThreadIndex;
 
         public bool isInvisibleDefault;
+        
+        public List<string> currentTags { get; set; }
 
         public Choice()
         {
+            currentTags = new List<string>();
         }
 	}
 }

--- a/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/JsonSerialisation.cs
@@ -600,6 +600,7 @@ namespace Ink.Runtime
             choice.sourcePath = jObj ["originalChoicePath"].ToString();
             choice.originalThreadIndex = (int)jObj ["originalThreadIndex"];
             choice.pathStringOnChoice = jObj ["targetPath"].ToString();
+            choice.currentTags = jObj["currentTags"] as List<string>;
             return choice;
         }
         public static void WriteChoice(SimpleJson.Writer writer, Choice choice)
@@ -610,6 +611,12 @@ namespace Ink.Runtime
             writer.WriteProperty("originalChoicePath", choice.sourcePath);
             writer.WriteProperty("originalThreadIndex", choice.originalThreadIndex);
             writer.WriteProperty("targetPath", choice.pathStringOnChoice);
+            writer.WritePropertyStart("currentTags");
+            writer.WriteArrayStart();
+            foreach (var tag in choice.currentTags)
+                writer.Write(tag);
+            writer.WriteArrayEnd();
+            writer.WritePropertyEnd();
             writer.WriteObjectEnd();
         }
 

--- a/Packages/Ink/InkLibs/InkRuntime/Story.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/Story.cs
@@ -1069,7 +1069,14 @@ namespace Ink.Runtime
 
             // Set final text for the choice
             choice.text = (startText + choiceOnlyText).Trim(' ', '\t');
-
+            foreach (var contentItem in choicePoint.choiceTarget.content)
+            {
+                if (contentItem is Tag)
+                {
+                    var tag = contentItem as Tag;
+                    choice.currentTags.Add(tag.text);
+                }
+            }
             return choice;
         }
 


### PR DESCRIPTION
Added ability to work with tags on the specific choice level. It's useful when the user wants to decorate a single choice in Unity (for example, to inform gamer, that this choice will cost some money or resources).
Syntax is following: 

`=== first_tutorial === 
Ok, I can do that for for you, but not for free # face:merchant
* [Ok] -> begin_deal # money:-20
* [Maybe later] -> skip_conversation`