### PR TITLE
Check is null _defaultGlobalVariables on WriteJson

### DIFF
--- a/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
+++ b/Packages/Ink/InkLibs/InkRuntime/VariablesState.cs
@@ -167,7 +167,8 @@ namespace Ink.Runtime
                 if(dontSaveDefaultValues) {
                     // Don't write out values that are the same as the default global values
                     Runtime.Object defaultVal;
-                    if (_defaultGlobalVariables.TryGetValue(name, out defaultVal))
+                    
+                    if (_defaultGlobalVariables!=null && _defaultGlobalVariables.TryGetValue(name, out defaultVal))
                     {
                         if (RuntimeObjectsEqual(val, defaultVal))
                             continue;


### PR DESCRIPTION
Fixed an issue when using story.ResetState() _defaultGlobalVariables is null and throws.