### PR TITLE
fix typos in search bar GUI style assignment

### DIFF
--- a/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
+++ b/Packages/Ink/Editor/Tools/Player Window/InkPlayerWindow.cs
@@ -1089,8 +1089,8 @@ namespace Ink.UnityIntegration {
 		}
         void OnGUI () {
 			HandleDragAndDrop();
-			if(searchTextFieldStyle == null) searchTextFieldStyle = GUI.skin.FindStyle("ToolbarSeachTextField");
-			if(searchCancelButtonStyle == null) searchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
+			if(searchTextFieldStyle == null) searchTextFieldStyle = GUI.skin.FindStyle("ToolbarSearchTextField");
+			if(searchCancelButtonStyle == null) searchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSearchCancelButton");
 
 			dateTimeNow = DateTime.Now;
 			var time = Time.realtimeSinceStartup;


### PR DESCRIPTION
this resulted in cascading GUI errors thanks to a null reference exception in the editor code: 
![image](https://github.com/inkle/ink-unity-integration/assets/3675735/4205bfca-c82a-407f-b857-81408e0a958c)
